### PR TITLE
Rename highlander to cfhighlander 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN rm cfhighlander-*.gem ; \
     rm -rf /src
 
 RUN adduser -u 1000 -D cfhighlander && \
-    apk add --update python py-pip git openssh-client && \
+    apk add --update python3 git openssh-client bash && \
+    ln $(which pip3) /bin/pip && \
     pip install awscli
 
 WORKDIR /work

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build Status](https://travis-ci.com/theonestack/cfhighlander.svg?branch=develop)](https://travis-ci.com/theonestack/cfhighlander)
 
-# Highlander
+# Cfhighlander
 
-Highlander is DSL processor that enables composition and orchestration of Amazon CloudFormation templates 
+Cfhighlander is DSL processor that enables composition and orchestration of Amazon CloudFormation templates 
 written using [CfnDsl](https://github.com/cfndsl/cfndsl) in an abstract way. It tries to tackle problem of merging multiple templates into master
 template in an elegant way, so higher degree of template reuse can be achieved. It does so by formalising commonly
 used patterns via DSL statements. For an example, passing output of one stack into other stack is achieved using 
@@ -48,7 +48,7 @@ this file defines map used within component itself
 - Define cfndsl template used for building CloudFormation resources
 
 
-**Outer component** is component that defines other component via higlander dsl `Component` statement. Defined component
+**Outer component** is component that defines other component via cfhighlander dsl `Component` statement. Defined component
 is called **inner component**. Components defined under same outer component are **sibling components**
 
 ## Usage
@@ -58,30 +58,30 @@ For both ways, highlander is distributed as ruby gem
 
 
 ```bash
-$ gem install highlander
-$ highlander help
-highlander commands:
-  highlander cfcompile component[@version] -f, --format=FORMAT   # Compile Highlander component to CloudFormation templates
-  highlander cfpublish component[@version] -f, --format=FORMAT   # Publish CloudFormation template for component, and it' referenced subcomponents
-  highlander configcompile component[@version]                   # Compile Highlander components configuration
-  highlander dslcompile component[@version] -f, --format=FORMAT  # Compile Highlander component configuration and create cfndsl templates
-  highlander help [COMMAND]                                      # Describe available commands or one specific command
-  highlander publish component[@version] [-v published_version]  # Publish CloudFormation template for component, and it' referenced subcomponents
+$ gem install cfhighlander
+$ cfhighlander help
+cfhighlander commands:
+  cfhighlander cfcompile component[@version] -f, --format=FORMAT   # Compile Highlander component to CloudFormation templates
+  cfhighlander cfpublish component[@version] -f, --format=FORMAT   # Publish CloudFormation template for component, and it' referenced subcomponents
+  cfhighlander configcompile component[@version]                   # Compile Highlander components configuration
+  cfhighlander dslcompile component[@version] -f, --format=FORMAT  # Compile Highlander component configuration and create cfndsl templates
+  cfhighlander help [COMMAND]                                      # Describe available commands or one specific command
+  cfhighlander publish component[@version] [-v published_version]  # Publish CloudFormation template for component, and it' referenced subcomponents
 
 ```
 ### Working directory
 
 All templates and configuration generated are placed in `$WORKDIR/out` directory. Optionally, you can alter working directory
-via `HIGHLANDER_WORKDIR` environment variable. 
+via `CFHIGHLANDER_WORKDIR` environment variable. 
 
 ### Commands
 
 To get full list of options for any of cli commands use `highlander help command_name` syntax
 
 ```bash
-$ highlander help publish
+$ cfhighlander help publish
 Usage:
-  highlander publish component[@version] [-v published_version]
+  cfhighlander publish component[@version] [-v published_version]
 
 Options:
       [--dstbucket=DSTBUCKET]  # Distribution S3 bucket
@@ -95,7 +95,7 @@ Publish CloudFormation template for component,
 
 #### Silent mode
 
-Highlander DSL processor has built-in support for packaging and deploying AWS Lambda functions. Some of these lambda
+Cfhighlander DSL processor has built-in support for packaging and deploying AWS Lambda functions. Some of these lambda
 functions may require shell command to be executed (e.g. pulling library dependencies) prior their packaging in ZIP archive format.
 Such commands are potential security risk, as they allow execution of arbitrary code, so for this reason user agreement is required
 e.g:
@@ -136,11 +136,11 @@ cfndsl templates. Check component configuration section for more details.
 
 #### dslcompile
 
-*dslcompile* will produce intermediary cfndsl templates. This is useful for debugging highlander components
+*dslcompile* will produce intermediary cfndsl templates. This is useful for debugging cfhighlander components
 
 #### publish
 
-*publish* command publishes highlander components source code to s3 location (compared to *cfpublish* which is publishing
+*publish* command publishes cfhighlander components source code to s3 location (compared to *cfpublish* which is publishing
 compiled cloudformation templates). Same CLI / DSL options apply as for *cfpublish* command. Version defaults to `latest`
 
 
@@ -408,4 +408,4 @@ so extension methods can be consumed within cfndsl template.
 
 Any extensions placed within `cfndsl_ext` folder will be 
 available in cfndsl templates of all components. Any extensions placed within `hl_ext` folder are 
-available in highlander templates of all components. 
+available in cfhighlander templates of all components. 

--- a/bin/cfhighlander
+++ b/bin/cfhighlander
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
 
-require_relative('./highlander')
+require_relative('./cfhighlander')

--- a/bin/cfhighlander.rb
+++ b/bin/cfhighlander.rb
@@ -9,7 +9,7 @@
 
 require 'thor'
 require 'rubygems'
-require_relative '../lib//highlander.compiler'
+require_relative '../lib/highlander.compiler'
 require_relative '../lib/highlander.factory'
 require_relative '../lib/highlander.publisher'
 require_relative '../lib/highlander.validator'
@@ -138,9 +138,7 @@ end
 
 # build component from passed cli options
 def build_component(options, component_name)
-  if ENV['HIGHLANDER_WORKDIR'].nil?
-    ENV['HIGHLANDER_WORKDIR'] = Dir.pwd
-  end
+
   component_version = options[:version]
   distribution_bucket = options[:dstbucket]
   distribution_prefix = options[:dstprefix]
@@ -153,6 +151,13 @@ def build_component(options, component_name)
   component.distribution_prefix = distribution_prefix unless distribution_prefix.nil?
   component.load
   component
+end
+
+if ENV['CFHIGHLANDER_WORKDIR'].nil?
+  ENV['CFHIGHLANDER_WORKDIR'] = Dir.pwd
+end
+if ENV['HIGHLANDER_WORKDIR'].nil?
+  ENV['HIGHLANDER_WORKDIR'] = Dir.pwd
 end
 
 HighlanderCli.start

--- a/lib/highlander.compiler.rb
+++ b/lib/highlander.compiler.rb
@@ -33,7 +33,7 @@ module Highlander
 
       def initialize(component)
 
-        @workdir = ENV['HIGHLANDER_WORKDIR']
+        @workdir = ENV['CFHIGHLANDER_WORKDIR']
         @component = component
         @sub_components = []
         @component_name = component.highlander_dsl.name.downcase

--- a/lib/highlander.dsl.rb
+++ b/lib/highlander.dsl.rb
@@ -397,7 +397,6 @@ def HighlanderComponent(&block)
   puts "Processing higlander component #{@name}\n\tLocation:#{@highlander_dsl_path}" +
       "\n\tConfig:#{@config}"
 
-  component_config = @config
 
   instance.config = @config
 
@@ -425,4 +424,8 @@ def HighlanderComponent(&block)
   instance.loadComponents
 
   return instance
+end
+
+def CfhighlanderComponent(&block)
+  HighlanderComponent(&block)
 end

--- a/lib/highlander.factory.rb
+++ b/lib/highlander.factory.rb
@@ -2,7 +2,7 @@ require_relative './highlander.dsl'
 require 'fileutils'
 require 'git'
 
-LOCAL_HIGHLANDER_CACHE_LOCATION = "#{ENV['HOME']}/.highlander/components"
+LOCAL_HIGHLANDER_CACHE_LOCATION = "#{ENV['HOME']}/.cfhighlander/components"
 
 module Highlander
 

--- a/lib/highlander.factory.rb
+++ b/lib/highlander.factory.rb
@@ -40,6 +40,7 @@ module Highlander
       def load_config()
         @config = {} if @config.nil?
         Dir["#{@component_dir}/*.config.yaml"].each do |config_file|
+          puts "Loading config for #{@name}:\n\tread #{config_file} "
           partial_config = YAML.load(File.read(config_file))
           unless partial_config.nil?
             @config.extend(partial_config)

--- a/spec/test_component_spec.rb
+++ b/spec/test_component_spec.rb
@@ -1,5 +1,6 @@
-require_relative '../bin/highlander'
+require_relative '../bin/cfhighlander'
 require 'git'
+require 'pp'
 
 RSpec.describe HighlanderCli, "#run" do
 
@@ -15,7 +16,10 @@ RSpec.describe HighlanderCli, "#run" do
       end
       Git.clone 'https://github.com/theonestack/hl-component-test', wd, clone_opts
 
-      is_travis_pr = (ENV['TRAVIS'] and ENV['TRAVIS_PULL_REQUEST'].to_i > 0)
+      puts("Environment:")
+      pp ENV
+
+      is_travis_pr = ((ENV.key? 'TRAVIS') and (ENV['TRAVIS_PULL_REQUEST'].to_i > 0))
 
       Dir.chdir wd
       ARGV.clear
@@ -36,7 +40,7 @@ RSpec.describe HighlanderCli, "#run" do
       # if running within travis and caused by PR, there are no creds available, thus
       # we have to mock the azs
       if is_travis_pr
-        File.write 'az.mappings.yaml', default_maps.to_yaml
+        File.write "#{ENV['HIGHLANDER_WORKDIR']}/az.mappings.yaml", default_maps.to_yaml
       end
 
       result = HighlanderCli.start


### PR DESCRIPTION
Updated
- cache template location
- added support for 
```
CfhighlanderComponent do
...
```
- updated readme
- `CFHIGHLANDER_WORKDIR` env var is considered rather than `HIGHLANDER_WORKDIR`
- by default docker image has python3
- there is verbose output when loading configuration yaml files. 