### PR TITLE
Params refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - gem build cfhighlander.gemspec
   - gem install cfhighlander-*.gem
   - which cfhighlander && cfhighlander help
-  - bundle exec rspec
+  - cfndsl -u && bundle exec rspec
 deploy:
   provider: rubygems
   api_key: "${RUBYGEMS_API_KEY}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 
-gem 'cfndsl'
+gem 'cfndsl', '~> 0.16'
 gem 'thor'
 gem 'highline', '>=1.7.10', '<1.8'
 gem 'aws-sdk-core', '~> 3', '<4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
-    cfndsl (0.16.3)
+    cfndsl (0.16.6)
     diff-lcs (1.3)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
@@ -61,7 +61,7 @@ DEPENDENCIES
   aws-sdk-core (~> 3, < 4)
   aws-sdk-ec2 (~> 1, < 2)
   aws-sdk-s3 (~> 1, < 2)
-  cfndsl
+  cfndsl (~> 0.16)
   git (~> 1.4, < 2)
   highline (>= 1.7.10, < 1.8)
   netaddr (~> 1.5, >= 1.5.1)

--- a/lib/cfhighlander.dsl.params.rb
+++ b/lib/cfhighlander.dsl.params.rb
@@ -31,13 +31,15 @@ module Cfhighlander
       def OutputParam(component:, name:, isGlobal: false, noEcho: false, type: 'String')
         STDERR.puts ("DEPRECATED: OutputParam #{name} - Use ComponentParam instead. Outputut params are " +
             "autorwired by name only, with component disregarded")
-        ComponentParam(name, '', isGlobal: isGlobal, noEcho: noEcho, type: type)
+        param = ComponentParam(name, '', isGlobal: isGlobal, noEcho: noEcho, type: type)
+        param.provided_value = "#{component}.#{name}"
       end
 
       def ComponentParam(name, defaultValue = '', isGlobal: false, noEcho: false, type: 'String', allowedValues: nil)
         param = Parameter.new(name, type, defaultValue, noEcho, isGlobal, allowedValues)
         param.config = @config
         addParam param
+        return param
       end
 
       def MappingParam(name, defaultValue = '', &block)
@@ -67,6 +69,7 @@ module Cfhighlander
         @default_value = defaultValue
         @is_global = isGlobal
         @allowed_values = allowed_values
+        @provided_value = nil
       end
 
     end

--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -169,6 +169,8 @@ module Cfhighlander
                     "Outputs.#{source_output}"
                 ]).to_json
               end
+            else
+              return Cfhighlander::Helper.parameter_cfndsl_value(param_value)
             end
           else
             return Cfhighlander::Helper.parameter_cfndsl_value(sub_component.param_values[param.name])

--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -1,6 +1,7 @@
 require_relative './cfhighlander.helper'
 require_relative './cfhighlander.dsl.base'
 require_relative './cfhighlander.factory'
+require 'cfndsl'
 
 module Cfhighlander
 
@@ -14,7 +15,6 @@ module Cfhighlander
       end
 
     end
-
 
     class Subcomponent < DslBase
 
@@ -100,9 +100,6 @@ module Cfhighlander
       end
 
       def load(component_config_override = {})
-        # check for component config on parent
-        parent = @parent
-
         # Highest priority is DSL defined configuration
         component_config_override.extend @config
 
@@ -111,9 +108,13 @@ module Cfhighlander
         @component_loaded.load @component_config_override
       end
 
+      def parameter(name:, value:)
+        @param_values[name] = value
+      end
+
       # Parameters should be lazy loaded, that is late-binding should happen once
       # all parameters and mappings are known
-      def load_parameters
+      def resolve_parameter_values(available_outputs)
         component_dsl = @component_loaded.highlander_dsl
         component_dsl.parameters.param_list.each do |component_param|
           param = Cfhighlander::Dsl::SubcomponentParameter.new
@@ -121,7 +122,8 @@ module Cfhighlander
           param.cfndsl_value = SubcomponentParamValueResolver.resolveValue(
               @parent,
               self,
-              component_param)
+              component_param,
+              available_outputs)
           @parameters << param
         end
       end
@@ -129,40 +131,60 @@ module Cfhighlander
     end
 
     class SubcomponentParamValueResolver
-      def self.resolveValue(component, sub_component, param)
+      def self.resolveValue(component, sub_component, param, available_outputs)
 
-        puts("Resolving parameter #{component.name} -> #{sub_component.name}.#{param.name}")
+        print("INFO Resolving parameter #{component.name} -> #{sub_component.name}.#{param.name}: ")
 
-        # check if there are values defined on component itself
+        # rule 1: check if there are values defined on component itself
         if sub_component.param_values.key?(param.name)
-          return Cfhighlander::Helper.parameter_cfndsl_value(sub_component.param_values[param.name])
+          puts " parameter value provided "
+
+          param_value = sub_component.param_values[param.name]
+          if param_value.include? '.'
+            source_component_name = param_value.split('.')[0]
+            source_output = param_value.split('.')[1]
+            source_component = component.subcomponents.find {|sc| sc.name == source_component_name}
+            # if source component exists
+            if not source_component.nil?
+              if source_component_name == sub_component.name
+                STDERR.puts "WARNING: Parameter value on component #{source_component_name} references component itself: #{param_value}"
+              else
+                return CfnDsl::Fn.new('GetAtt', [
+                    source_component_name,
+                    "Outputs.#{source_output}"
+                ]).to_json
+              end
+            end
+          else
+            return Cfhighlander::Helper.parameter_cfndsl_value(sub_component.param_values[param.name])
+          end
         end
 
-        if param.class == Cfhighlander::Dsl::StackParam
-          return self.resolveStackParamValue(component, sub_component, param)
-        elsif param.class == Cfhighlander::Dsl::ComponentParam
-          return self.resolveComponentParamValue(component, sub_component, param)
-        elsif param.class == Cfhighlander::Dsl::MappingParam
+        # rule 1.1 mapping parameters are handled differently.
+        # TODO wire mapping parameters outside of component
+        if param.class == Cfhighlander::Dsl::MappingParam
+          puts " mapping parameter"
           return self.resolveMappingParamValue(component, sub_component, param)
-        elsif param.class == Cfhighlander::Dsl::OutputParam
-          return self.resolveOutputParamValue(component, sub_component, param)
-        else
-          raise "#{param.class} not resolvable to parameter value"
         end
-      end
 
-      def self.resolveStackParamValue(component, sub_component, param)
-        param_name = param.is_global ? param.name : "#{sub_component.name}#{param.name}"
-        return "Ref('#{param_name}')"
-      end
+        # rule #2: match output values from other components
+        #          by parameter name
+        if available_outputs.key? param.name
+          component_name = available_outputs[param.name].component.name
+          puts " resolved as output of #{component_name}"
+          return CfnDsl::Fn.new('GetAtt', [
+              component_name,
+              "Outputs.#{param.name}"
+          ]).to_json
+        end
 
-      def self.resolveComponentParamValue(component, sub_component, param)
-        # check component config for param value
-        # TODO
-        # check stack config for param value
-        # TODO
-        # return default value
-        return "'#{param.default_value}'"
+        # by default bubble parameter and resolve as reference on upper level
+        propagated_param = param.clone
+        propagated_param.name = "#{sub_component.name}#{param.name}" unless param.is_global
+        component.parameters.addParam propagated_param
+        puts " no autowiring candidates, propagate parameter to parent"
+        return CfnDsl::RefDefinition.new(propagated_param.name).to_json
+
       end
 
       def self.resolveMappingParamValue(component, sub_component, param)
@@ -208,36 +230,8 @@ module Cfhighlander
         end
 
         return value
-
-
-        return value
       end
 
-      def self.resolveOutputParamValue(component, sub_component, param)
-        component_name = param.component
-        resource_name = nil
-        if not sub_component.export_config.nil?
-          if sub_component.export_config.key? component_name
-            resource_name = sub_component.export_config[component_name]
-          end
-        end
-
-        if resource_name.nil?
-          # find by component
-          resource = component.components.find {|c| c.name == component_name}
-          resource_name = resource.name unless resource.nil?
-          if resource_name.nil?
-            resource = component.components.find {|c| c.template == component_name}
-            resource_name = resource.name unless resource.nil?
-          end
-        end
-
-        if resource_name.nil?
-          raise "#{sub_component.name}.Params.#{param.name}: Failed to resolve OutputParam '#{param.name}' with source '#{component_name}'. Component not found!"
-        end
-
-        return "FnGetAtt('#{resource_name}','Outputs.#{param.name}')"
-      end
     end
 
   end

--- a/lib/cfhighlander.factory.rb
+++ b/lib/cfhighlander.factory.rb
@@ -1,4 +1,4 @@
-require_relative './cfhighlander.dsl'
+require_relative './cfhighlander.dsl.template'
 require_relative './cfhighlander.factory.templatefinder'
 require_relative './cfhighlander.model.component'
 require 'fileutils'

--- a/lib/cfhighlander.helper.rb
+++ b/lib/cfhighlander.helper.rb
@@ -11,7 +11,7 @@ module Cfhighlander
       end
 
       if value.class == Hash
-        return value.to_s
+        return value.to_json
       end
 
       return "'#{value}'"

--- a/templates/cfndsl.component.template.erb
+++ b/templates/cfndsl.component.template.erb
@@ -8,7 +8,7 @@ CloudFormation do
 <% end %>
 
 # render subcomponents
-<% for @component in dsl.components %>
+<% for @component in dsl.subcomponents %>
     CloudFormation_Stack('<%= @component.name.gsub('-','').gsub('_','') %>') do
     TemplateURL '<%= @component.distribution_url %>'
     Parameters ({
@@ -37,6 +37,9 @@ CloudFormation do
       Default '<%= @param.default_value %>'
       <% unless @param.no_echo.nil? %>
       NoEcho <%= @param.no_echo.to_s %>
+      <% end %>
+      <% unless @param.allowed_values.nil? %>
+        AllowedValues <%= @param.allowed_values.to_s %>
       <% end %>
     end
 <% end %>


### PR DESCRIPTION

1. Implements https://github.com/theonestack/cfhighlander/issues/8 partially. 

- MappingParam externalisation not implemented
- Suggestions for `cfout` and `cfmap` not implemented

All of the legacy statements will flush DEPRECATION messages. 

----
2. Full example on new parameter usage can be found at test component, 'c1' template - https://github.com/theonestack/hl-component-test/blob/master/c1/c1.cfhighlander.rb

----

3. Enforces usage of `CfhighlanderTemplate` syntax, rather than `HighlanderComponent` as top level DSL statement

----
4. Added `allowedValues:` name parameter on `ComponentParam` statement, allowing enum specification. Also, named `type:` parameter is now properly rendered in resulting CloudFormation template. 

-----
5. Updated testing procedure so that latest cloudformation resource specification is downloaded using `cfndsl -u` prior test execution. 

