### PR TITLE
allow configuration file named per component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build-iPhoneSimulator/
 .rvmrc
 out
 gem/*.gem
+install.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 
 gem 'cfndsl', '~> 0.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
@@ -71,4 +71,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ components:
 
 ```
 This configuration level overrides component's own config file.
+Alternatively, to keep things less nested in configuration hierarchy, creating config file `vpc.config.yaml`
+for component named `vpc` works just as well:
+
+```yaml
+
+# contents of vpc.config.yaml in outer component, defining vpc component
+
+# line below prevents component configuration file being merged with outer component configuration
+subcomponent_config_file:  
+
+# there is no need for components/vpc/config structure, it is implied by file name
+maximum_availibility_zones: 3
+
+
+```
 
 
 - Outer component explicit configuration. You can pass `config` named parameter to `Component` statement, such as

--- a/lib/cfhighlander.compiler.rb
+++ b/lib/cfhighlander.compiler.rb
@@ -29,7 +29,8 @@ module Cfhighlander
           :cfn_output_location,
           :cfn_template_paths,
           :silent_mode,
-          :lambda_src_paths
+          :lambda_src_paths,
+          :process_lambdas
 
       def initialize(component)
 
@@ -45,6 +46,7 @@ module Cfhighlander
         @lambda_src_paths = []
         @config_yaml_path = nil
         @cfn_model = nil
+        @process_lambdas = true
 
         if @@global_extensions_paths.empty?
           global_extensions_folder = "#{File.dirname(__FILE__)}/../cfndsl_ext"
@@ -56,6 +58,11 @@ module Cfhighlander
           sub_component_compiler.component_name = sub_component.name
           @sub_components << sub_component_compiler
         end
+      end
+
+      def process_lambdas=(value)
+        @process_lambdas = value
+        @sub_components.each { |scc| scc.process_lambdas=value }
       end
 
       def silent_mode=(value)
@@ -177,14 +184,13 @@ module Cfhighlander
       end
 
       def processLambdas()
-
         @component.highlander_dsl.lambda_functions_keys.each do |lfk|
           resolver = LambdaResolver.new(@component,
               lfk,
               @workdir,
               (not @silent_mode)
           )
-          @lambda_src_paths += resolver.generateSourceArchives
+          @lambda_src_paths += resolver.generateSourceArchives if @process_lambdas
           resolver.mergeComponentConfig
         end
 

--- a/lib/cfhighlander.dsl.template.rb
+++ b/lib/cfhighlander.dsl.template.rb
@@ -2,7 +2,7 @@
 
 extensions_folder = "#{File.dirname(__FILE__)}/../hl_ext"
 
-Dir["#{extensions_folder}/*.rb"].each {|f|
+Dir["#{extensions_folder}/*.rb"].each { |f|
   require f
 }
 
@@ -37,7 +37,9 @@ module Cfhighlander
           :description,
           :dependson_components
 
-      attr_reader :conditions, :subcomponents
+      attr_reader :conditions,
+          :subcomponents,
+          :config_overrides
 
       def initialize
         @mappings = []
@@ -53,6 +55,7 @@ module Cfhighlander
         @dependson_components_templates = []
         @dependson_components = []
         @conditions = []
+        @config_overrides = {}
       end
 
       # DSL statements
@@ -88,7 +91,7 @@ module Cfhighlander
 
       def DynamicMappings(providerName)
         maps = mappings_provider_maps(providerName, self.config)
-        maps.each {|name, map| addMapping(name, map)} unless maps.nil?
+        maps.each { |name, map| addMapping(name, map) } unless maps.nil?
       end
 
       def DependsOn(template)
@@ -183,8 +186,8 @@ module Cfhighlander
       def loadComponents()
 
         # empty config overrides to start with
-        @config_overrides = Hash[@subcomponents.collect {|c| [c.name, { 'nested_component' => true }]}]
-        @named_components = Hash[@subcomponents.collect {|c| [c.name, c]}]
+        @config_overrides = Hash[@subcomponents.collect { |c| [c.name, { 'nested_component' => true }] }]
+        @named_components = Hash[@subcomponents.collect { |c| [c.name, c] }]
 
         # populate overrides with master config defined overrides
         load_configfile_component_config
@@ -283,14 +286,14 @@ module Cfhighlander
       end
 
       def apply_config_overrides
-        @config_overrides.each {|component_name, component_override|
+        @config_overrides.each { |component_name, component_override|
           @named_components[component_name].component_loaded.config.extend(component_override)
         }
       end
 
       def load_configfile_component_config
         if (@config.key? 'components')
-          @config['components'].each {|component_name, component_config|
+          @config['components'].each { |component_name, component_config|
             if component_config.key?('config')
               if @config_overrides.key? component_name
                 @config_overrides[component_name].extend(component_config['config'])
@@ -305,28 +308,28 @@ module Cfhighlander
       def apply_config_exports
         # first export from master to all children
         if ((@config.key? 'config_export') and (@config['config_export']['global']))
-          @config['config_export']['global'].each {|global_export_key|
+          @config['config_export']['global'].each { |global_export_key|
             if @config.key? global_export_key
-              @config_overrides.each {|cname, co|
+              @config_overrides.each { |cname, co|
                 co[global_export_key] = @config[global_export_key]
               }
             end
           }
         end
 
-        @subcomponents.each {|component|
+        @subcomponents.each { |component|
           cl = component.component_loaded
           if ((not cl.config.nil?) and (cl.config.key? 'config_export'))
 
             # global config
             if cl.config['config_export'].key? 'global'
-              cl.config['config_export']['global'].each {|global_export_key|
+              cl.config['config_export']['global'].each { |global_export_key|
 
                 # global config is exported to parent and every component
                 if cl.config.key? global_export_key
 
                   # cname is for component name, co for component override
-                  @config_overrides.each {|cname, co|
+                  @config_overrides.each { |cname, co|
 
                     # if templates are different e.g don't export from vpc to vpc
                     config_receiver_component = @named_components[cname]
@@ -352,7 +355,7 @@ module Cfhighlander
             end
 
             if cl.config['config_export'].key? 'component'
-              cl.config['config_export']['component'].each {|component_name, export_keys|
+              cl.config['config_export']['component'].each { |component_name, export_keys|
                 # check if there is configuration of export from this component
                 # and if there is export configuration for given component name
 
@@ -361,7 +364,7 @@ module Cfhighlander
                   if @config_overrides.key? component.export_config[component_name]
                     # override the config
                     real_component_name = component.export_config[component_name]
-                    export_keys.each {|export_component_key|
+                    export_keys.each { |export_component_key|
                       puts("Exporting config for key=#{export_component_key} from #{component.name} to #{real_component_name}")
                       if not @config_overrides[real_component_name].key? export_component_key
                         @config_overrides[real_component_name][export_component_key] = {}
@@ -372,7 +375,7 @@ module Cfhighlander
                     STDERR.puts("Trying to export configuration for non-existant component #{component.export_config[component_name]}")
                   end
                 elsif @config_overrides.key? component_name
-                  export_keys.each {|export_component_key|
+                  export_keys.each { |export_component_key|
                     puts("Exporting config for key=#{export_component_key} from #{component.name} to #{component_name}")
                     if not @config_overrides[component_name].key? export_component_key
                       @config_overrides[component_name][export_component_key] = {}
@@ -392,9 +395,10 @@ module Cfhighlander
       end
 
       def load_explicit_component_config
-        @component_configs.each {|component_name, component_config|
+        @component_configs.each { |component_name, component_config|
           @config_overrides[component_name].extend(component_config)
         }
+
       end
 
       def distribute_bucket=(value)
@@ -415,7 +419,7 @@ module Cfhighlander
         if not (@distribution_bucket.nil? or @distribution_prefix.nil?)
           @distribute_url = "https://#{@distribution_bucket}.s3.amazonaws.com/#{@distribution_prefix}"
           @distribute_url = "#{@distribute_url}/#{@version}" unless @version.nil?
-          @subcomponents.each {|component|
+          @subcomponents.each { |component|
             component.distribute_bucket = @distribution_bucket unless @distribution_bucket.nil?
             component.distribute_prefix = @distribution_prefix unless @distribution_prefix.nil?
             component.version = @version unless @version.nil?
@@ -457,6 +461,16 @@ def CfhighlanderTemplate(&block)
 
   instance.name = @template.template_name
   instance.instance_eval(&block)
+
+  # process convention over configuration componentname.config.yaml files
+  @potential_subcomponent_overrides.each do |name, config|
+    if (not instance.subcomponents.find{|s|s.name == name}.nil?)
+      instance.config['components'] = {} unless instance.config.key? 'components'
+      instance.config['components'][name] = {} unless instance.config['components'].key? name
+      instance.config['components'][name]['config'] = {} unless instance.config['components'][name].key? 'config'
+      instance.config['components'][name]['config'].extend config
+    end
+  end
 
   # load sub-components
   instance.loadComponents


### PR DESCRIPTION
implements https://github.com/theonestack/cfhighlander/issues/28

If component configuration file contains `subcomponent_config_file: ` key, disregarding the value of this key, configuration won't be merged to master config. Otherwise anything found within yaml file is merged both to master config, and to appropriate component config. 

One idea coming out of this implementation is having a `cfhighlander scconfigextract` command which will generate these files for every subcomponent referenced in the template. 



