### PR TITLE
Component inheritance

### DIFF
--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -152,7 +152,7 @@ module Cfhighlander
     class SubcomponentParamValueResolver
       def self.resolveValue(component, sub_component, param, available_outputs)
 
-        print("INFO Resolving parameter #{component.name} -> #{sub_component.name}.#{param.name}: ")
+        puts("INFO Resolving parameter #{component.name} -> #{sub_component.name}.#{param.name}: ")
 
         # rule 0: this rule is here for legacy reasons and OutputParam. It should be deprecated
         # once all hl-components- repos remove any references to OutputParam

--- a/lib/cfhighlander.dsl.template.rb
+++ b/lib/cfhighlander.dsl.template.rb
@@ -39,7 +39,8 @@ module Cfhighlander
 
       attr_reader :conditions,
           :subcomponents,
-          :config_overrides
+          :config_overrides,
+          :extended_template
 
       def initialize
         @mappings = []
@@ -55,7 +56,8 @@ module Cfhighlander
         @dependson_components_templates = []
         @dependson_components = []
         @conditions = []
-        @config_overrides = {}
+        @config_overrides = {},
+        @extended_template = nil
       end
 
       # DSL statements
@@ -98,6 +100,9 @@ module Cfhighlander
         @dependson_components_templates << template
       end
 
+      def Extends(template)
+        @extended_template = template
+      end
 
       def Component(template_arg = nil, template: nil,
           name: template,
@@ -435,11 +440,16 @@ module Cfhighlander
 end
 
 def CfhighlanderTemplate(&block)
-  instance = Cfhighlander::Dsl::HighlanderTemplate.new
 
-  puts "Processing cfhighlander component #{@name}\n\tLocation:#{@highlander_dsl_path}" +
-      "\n\tConfig:#{@config}"
-
+  if @parent_dsl.nil?
+    instance = Cfhighlander::Dsl::HighlanderTemplate.new
+    puts "Processing higlander component #{@name}\n\tLocation:#{@highlander_dsl_path}" +
+        "\n\tConfig:#{@config}"
+  else
+    instance = @parent_dsl
+    puts "Processing higlander component #{@name}\n\tLocation:#{@highlander_dsl_path}" +
+        "\n\tConfig:#{@config}\n\tParent: #{@parent_template}"
+  end
 
   instance.config = @config
 

--- a/lib/cfhighlander.factory.rb
+++ b/lib/cfhighlander.factory.rb
@@ -34,7 +34,10 @@ module Cfhighlander
 
 
       def buildComponentFromLocation(template_meta, component_name)
-        component = Model::Component.new(template_meta, component_name)
+        component = Model::Component.new(template_meta,
+            component_name,
+            self)
+        component.factory = self
         component.load_config
         return component
       end

--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -20,13 +20,21 @@ module Cfhighlander
           :distribution_prefix,
           :component_files,
           :cfndsl_ext_files,
-          :lambda_src_files
+          :lambda_src_files,
+          :parent_template,
+          :template_finder,
+          :factory,
+          :extended_component,
+          :is_parent_component
 
       attr_reader :cfn_model,
           :outputs,
+          :factory,
+          :extended_component,
           :potential_subcomponent_overrides
 
-      def initialize(template_meta, component_name)
+
+      def initialize(template_meta, component_name, factory)
         @template = template_meta
         @name = component_name
         @component_dir = template_meta.template_location
@@ -37,7 +45,11 @@ module Cfhighlander
         @component_files = []
         @cfndsl_ext_files = []
         @lambda_src_files = []
+        @factory = factory
+        @extended_component = nil
+        @parent_dsl = nil
         @potential_subcomponent_overrides = {}
+        @is_parent_component = false
       end
 
       # load component configuration files
@@ -51,7 +63,7 @@ module Cfhighlander
             @component_files << config_file
           end
           fname = File.basename(config_file)
-          potential_component_name = fname.gsub('.config.yaml','')
+          potential_component_name = fname.gsub('.config.yaml', '')
           @potential_subcomponent_overrides[potential_component_name] = partial_config
         end
       end
@@ -85,7 +97,7 @@ module Cfhighlander
         candidate_dynamic_mappings_path = "#{@component_dir}/#{@template.template_name}.mappings.rb"
 
         @cfndsl_ext_files += Dir["#{@component_dir}/ext/cfndsl/*.rb"]
-        @lambda_src_files += Dir["#{@component_dir}/lambdas/**/*"].find_all {|p| not File.directory? p}
+        @lambda_src_files += Dir["#{@component_dir}/lambdas/**/*"].find_all { |p| not File.directory? p }
         @component_files += @cfndsl_ext_files
         @component_files += @lambda_src_files
 
@@ -111,16 +123,11 @@ module Cfhighlander
           @component_files << candidate_dynamic_mappings_path
         end
 
-        # 1st pass - parse the file
         @component_files << @highlander_dsl_path
 
-        cfhl_script = ''
-        @config.each do |key, val|
-          cfhl_script += ("\n#{key} = #{val.inspect}\n")
-        end
-        cfhl_script += File.read(@highlander_dsl_path)
 
-        @highlander_dsl = eval(cfhl_script, binding)
+        # evaluate template file and load parent if defined
+        evaluateHiglanderTemplate
 
         # set version if not defined
         @highlander_dsl.ComponentVersion(@version) unless @version.nil?
@@ -135,12 +142,39 @@ module Cfhighlander
           end
 
           @highlander_dsl.Description(description)
-        end
+        end unless @is_parent_component
 
         # set (override) distribution options
         @highlander_dsl.DistributionBucket(@distribution_bucket) unless @distribution_bucket.nil?
         @highlander_dsl.DistributionPrefix(@distribution_prefix) unless @distribution_prefix.nil?
 
+
+        loadDepandantExt()
+      end
+
+      def inheritParentTemplate
+        if not @parent_template.nil?
+          extended_component = @factory.loadComponentFromTemplate(@parent_template)
+          extended_component.is_parent_component = true
+          extended_component.load()
+
+          @config = extended_component.config.extend(@config)
+          @mappings = extended_component.mappings.extend(@mappings)
+          @cfndsl_ext_files += extended_component.cfndsl_ext_files
+          @lambda_src_files += extended_component.lambda_src_files
+          @extended_component = extended_component
+
+          # extend cfndsl, first comes parent, than child
+          # this allows for child component to shadow parent component
+          # defined resources
+          @cfndsl_content = extended_component.cfndsl_content + @cfndsl_content
+
+          @parent_dsl = extended_component.highlander_dsl
+
+        end
+      end
+
+      def loadCfndslContent
         if File.exist? @cfndsl_path
           @component_files << @cfndsl_path
           @cfndsl_content = File.read(@cfndsl_path)
@@ -155,8 +189,27 @@ module Cfhighlander
         else
           @cfndsl_content = ''
         end
+      end
 
-        loadDepandantExt()
+      def evaluateHiglanderTemplate
+        loadCfndslContent
+
+        cfhl_script = ''
+        @config.each do |key, val|
+          cfhl_script += ("\n#{key} = #{val.inspect}\n")
+        end
+        cfhl_script += File.read(@highlander_dsl_path)
+
+        cfhl_dsl = eval(cfhl_script, binding)
+        if not cfhl_dsl.extended_template.nil?
+          @parent_template = cfhl_dsl.extended_template
+          inheritParentTemplate
+          puts "INFO: #{@template} extends #{@parent_template}, loading parent definition..."
+          # 2nd pass, template instance is already created from parent
+          @highlander_dsl = eval(cfhl_script, binding)
+        else
+          @highlander_dsl = cfhl_dsl
+        end
       end
 
       # evaluates cfndsl with current config
@@ -169,7 +222,7 @@ module Cfhighlander
         @outputs = (
         if @cfn_model.key? 'Outputs'
         then
-          @cfn_model['Outputs'].map {|k, v| ComponentOutput.new self, k, v}
+          @cfn_model['Outputs'].map { |k, v| ComponentOutput.new self, k, v }
         else
           []
         end


### PR DESCRIPTION
## Extending components with other components in less than 100LOC 

Implements https://github.com/theonestack/cfhighlander/issues/9

### Design aspects

Cfhighlander as infrastructure coding tool should tend to makes use of well known 
concepts of traditional software engineering, and apply them to infrastructure
coding practice. One of the basic concepts of OOP is class inheritance, and this PR applies
this concept to cfhighlander templates. Templates, as first class citizens in cfhighlander world, should be able to inherit, extend, and shadow behaviour of their parent templates. 

## Details
 
Everything except for template name, version and description is being inherited from  parent
template by child template. Dsl Statement for inheritance is simple `Extends` , borrowed from
Java. 

### Cfndsl templates

Cfndsl content of child template is appended to parent template. This way, child can shadow resources defined in parent by giving them same name


### Component configuration

Any configuration key values defined by parent template can be overwritten in child template.

### Highlander Statements

Highlander statements (parameters, lambda functions, subcomponents) are all inherited from parent.
In-memory model effectively creates single instance of `CfhighlanderTemplate` object model, and applies all DSL statements (meaning both from parent and child templates) to this instance. 
 
First, parent DSL methods are applied
 
Secondly, child DSL methods are applied. You can shadow parent definitions here, or extend their capabilities by adding DSL statements. 

## Testing

Repository with relevant examples can be found [here](https://github.com/toshke/cfhighlander-demo-inheritance).  Also, travis build that uses source code from this branch to compile templates making use of inheritance feature can be found at https://travis-ci.org/toshke/cfhighlander-demo-inheritance




