### PR TITLE
bugfix: lambda packaging when downloading from https sources

### DIFF
--- a/lib/cfhighlander.compiler.rb
+++ b/lib/cfhighlander.compiler.rb
@@ -257,6 +257,7 @@ module Cfhighlander
               IO.copy_stream(download, "#{out_folder}/src.zip")
               FileUtils.mkdir_p('.cache/lambdas')
               FileUtils.copy("#{out_folder}/src.zip", cached_location)
+              FileUtils.copy("#{out_folder}/src.zip", full_destination_path)
               puts "Download complete, caching in #{cached_location}"
               cached_downloads[lambda_config['code']] = cached_location
             end

--- a/lib/util/zip.util.rb
+++ b/lib/util/zip.util.rb
@@ -30,7 +30,7 @@ module Cfhighlander
         entries.each do |e|
           zipfile_path = path == '' ? e : File.join(path, e)
           disk_file_path = File.join(@input_dir, zipfile_path)
-          puts "Deflating #{disk_file_path}"
+          puts "TRACE: Deflating #{disk_file_path}"
 
           if File.directory? disk_file_path
             recursively_deflate_directory(disk_file_path, zipfile, zipfile_path)


### PR DESCRIPTION
This PR is in addition to https://github.com/theonestack/cfhighlander/pull/30. Essentially, in case of lambda functions being pulled down from remote location, caching mechanism works, however first compile does not, as cached zip file is not copied to appropriate location alongside with compiled cloudformation templates. 

Example of lambda configuration with code from http(s) source:

```yaml
ccr:
  custom_policies:
    cognito:
      action:
        - cognito-idp:*
  roles:
    cognito:
      policies_inline:
        - cloudwatch-logs
        - cognito
  functions:
    ccrCognitoUPC:
      role: cognito
      code: http://customresources.sourcecode.example.com.s3.amazonaws.com/build/ccr-nodejs-d743344.zip
      runtime: nodejs6.10
      named: false
      timeout: 30
      handler: cognito-user-pool-client/index.js
```

```ruby
CfhighlanderTemplate do
  Name 'cognito'
  LambdaFunctions 'ccr'
end
```