### PR TITLE
Bugfix: Propagate distribution settings from outer to inner component…

### DIFF
--- a/lib/cfhighlander.dsl.template.rb
+++ b/lib/cfhighlander.dsl.template.rb
@@ -452,15 +452,16 @@ def CfhighlanderTemplate(&block)
     instance.config['component_version'] = @version
   end
 
+
+  instance.name = @template.template_name
+  instance.instance_eval(&block)
+
   unless @distribution_bucket.nil?
     instance.DistributionBucket(@distribution_bucket)
   end
   unless @distribution_prefix.nil?
     instance.DistributionPrefix(@distribution_prefix)
   end
-
-  instance.name = @template.template_name
-  instance.instance_eval(&block)
 
   # process convention over configuration componentname.config.yaml files
   @potential_subcomponent_overrides.each do |name, config|

--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -40,6 +40,20 @@ module Cfhighlander
         @potential_subcomponent_overrides = {}
       end
 
+      def distribution_bucket=(value)
+        if not @highlander_dsl.nil?
+          @highlander_dsl.DistributionBucket(value)
+        end
+        @distribution_bucket = value
+      end
+
+      def distribution_prefix=(value)
+        if not @highlander_dsl.nil?
+          @highlander_dsl.DistributionPrefix(value)
+        end
+        @distribution_prefix = value
+      end
+
       # load component configuration files
       def load_config()
         @config = {} if @config.nil?


### PR DESCRIPTION
When `--dstprefix and --dstbucket` are given on command line, they work just fine on outer/master template being compiled. But this does not get propagated to inner components, resulting in lambda source code or substack template urls being set incorrectly. 