### PR TITLE
support legacy component configuration

### DIFF
--- a/hl_ext/common_helper.rb
+++ b/hl_ext/common_helper.rb
@@ -1,12 +1,12 @@
 class ::Hash
   def deep_merge(second)
-    merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : Array === v1 && Array === v2 ? v1 | v2 : [:undefined, nil, :nil].include?(v2) ? v1 : v2 }
+    merger = proc {|key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : Array === v1 && Array === v2 ? v1 | v2 : [:undefined, nil, :nil].include?(v2) ? v1 : v2}
     self.merge(second.to_h, &merger)
   end
 
 
   def extend(second)
-    second.each { |k, v|
+    second.each {|k, v|
 
       if ((self.key? k) and (v.is_a? Hash and self[k].is_a? Hash))
         self[k].extend(v)

--- a/lib/cfhighlander.dsl.template.rb
+++ b/lib/cfhighlander.dsl.template.rb
@@ -475,10 +475,22 @@ def CfhighlanderTemplate(&block)
 
   # process convention over configuration componentname.config.yaml files
   @potential_subcomponent_overrides.each do |name, config|
+
+    # if there is component with given file name
     if (not instance.subcomponents.find{|s|s.name == name}.nil?)
       instance.config['components'] = {} unless instance.config.key? 'components'
       instance.config['components'][name] = {} unless instance.config['components'].key? name
       instance.config['components'][name]['config'] = {} unless instance.config['components'][name].key? 'config'
+
+      # prevention of infinite recursion when applied to legacy configurations
+      if config.key? 'components'
+        if config['components'].key? name
+          if config['components'][name].key? 'config'
+           config = config['components'][name]['config']
+          end
+        end
+      end
+
       instance.config['components'][name]['config'].extend config
     end
   end

--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -72,6 +72,10 @@ module Cfhighlander
         Dir["#{@component_dir}/*.config.yaml"].each do |config_file|
           puts "INFO Loading config for #{@name}: read file:#{config_file} "
           partial_config = YAML.load(File.read(config_file))
+          if (not partial_config)
+            STDERR.puts "WARNING: Configuration file #{config_file} could not be loaded"
+            next
+          end
           unless (partial_config.nil? or partial_config.key? 'subcomponent_config_file')
             @config.extend(partial_config)
             @component_files << config_file


### PR DESCRIPTION
## Bug fixes

### Component configuration `component.config.yaml` issue

Inner components configuration used be defined as 

```yaml
components:
  vpc:
     config:
        key: value
```

Now, when this is placed within `vpc.config.yaml`, and new feature #28 , this will cause infinite recursion when compiling outer component

```shell
WARN: Overriding config for non-existing component waf-regional
/Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:9:in `each': stack level too deep (SystemStackError)
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:9:in `extend'
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:12:in `block in extend'
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:9:in `each'
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:9:in `extend'
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:12:in `block in extend'
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:9:in `each'
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:9:in `extend'
	from /Users/nikolatosic/Projects/theonestack/cfhighlander/hl_ext/common_helper.rb:12:in `block in extend'
```

### Invalid YAML configuration files

If there is YAML file in configuration that is not properly formatted, or has any syntax error (or is empty), following exception is being thrown

```bash
cfhighlander.model.component.rb:75:in `block in load_config': undefined method `key?' for false:FalseClass (NoMethodError)
```

This PR adds WARNING output for this case, rather than having whole process to fail. 

