### PR TITLE
allow cfcompile and cfpublish directly

### DIFF
--- a/bin/cfcompile
+++ b/bin/cfcompile
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+ARGV.unshift('cfcompile')
+require_relative('./cfhighlander')

--- a/bin/cfpublish
+++ b/bin/cfpublish
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+ARGV.unshift('cfpublish')
+require_relative('./cfhighlander')

--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/theonestack/cfhighlander/blob/master/README.md'
   s.license = 'MIT'
   s.executables << 'cfhighlander'
+  s.executables << 'cfcompile'
+  s.executables << 'cfpublish'
 
   s.add_runtime_dependency 'highline', '>=1.7.10','<1.8'
   s.add_runtime_dependency 'thor', '~>0.20', '<1'


### PR DESCRIPTION
This PR adds 2 new executables - `cfpublish` and `cfcompile` to cfhighlander gem. Makes everyday life easier, as `cd $COMPONENT && cfcompile` command will work perfectly fine. `cfcompile` by default tries to locate component highlander file in current directory if no argument is given. 