### PR TITLE
Advanced manipulation of inner component to outer component

### DIFF
--- a/bin/cfhighlander.rb
+++ b/bin/cfhighlander.rb
@@ -16,9 +16,7 @@ require_relative '../lib/cfhighlander.validator'
 
 class HighlanderCli < Thor
 
-
-
-  package_name "highlander"
+  package_name "cfhighlander"
 
   desc 'configcompile component[@version]', 'Compile Highlander components configuration'
 

--- a/lib/cfhighlander.compiler.rb
+++ b/lib/cfhighlander.compiler.rb
@@ -276,6 +276,7 @@ module Cfhighlander
             # executing package command can generate files. We DO NOT want this file in source directory,
             # but rather in intermediate directory
             tmp_source_dir = "#{@workdir}/out/lambdas/tmp/#{name}"
+            FileUtils.rmtree(File.dirname(tmp_source_dir)) if File.exist? tmp_source_dir
             FileUtils.mkpath(File.dirname(tmp_source_dir))
             FileUtils.copy_entry(lambda_source_dir, tmp_source_dir)
             lambda_source_dir = tmp_source_dir

--- a/lib/cfhighlander.dsl.base.rb
+++ b/lib/cfhighlander.dsl.base.rb
@@ -1,4 +1,3 @@
-
 module Cfhighlander
 
   module Dsl
@@ -6,7 +5,52 @@ module Cfhighlander
 
       attr_accessor :config
 
-      def initialize(parent)
+
+      def GetAtt(resource, property)
+        return FnGetAtt(resource, property)
+      end
+
+      def FnGetAtt(resource, property)
+        return {
+            'Fn::GetAtt' => [resource, property]
+        }
+      end
+
+      def Ref(resource)
+        return {
+            'Ref' => resource
+        }
+      end
+
+      def FnFindInMap(map, key, attr)
+        return { 'Fn::FindInMap' => [map, key, attr] }
+      end
+
+      def FindInMap(map, key, attr)
+        return FnFindInMap(map, key, attr)
+      end
+
+      def cfout(resource, output = nil)
+        if output.nil?
+          parts = resource.split('.')
+          if parts.size() != 2
+            raise "cfout('#{resource}'): If cfout given single argument cfout('component.OutputName') syntax must be used"
+          else
+            resource = parts[0]
+            output = parts[1]
+          end
+        end
+
+        return GetAtt(resource, "Outputs.#{output}")
+      end
+
+
+      def cfmap(map, key, attr)
+        return FindInMap(map, key, attr)
+      end
+
+
+      def initialize (parent)
         @config = parent.config unless parent.nil?
       end
 

--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -63,7 +63,7 @@ module Cfhighlander
         @template = template_name
         @template_version = template_version
         @name = name
-        @cfn_name = @name.gsub('-','').gsub('_','').gsub(' ','')
+        @cfn_name = @name.gsub('-', '').gsub('_', '').gsub(' ', '')
         @param_values = param_values
 
         # distribution settings
@@ -129,6 +129,26 @@ module Cfhighlander
 
       def parameter(name:, value:)
         @param_values[name] = value
+      end
+
+      def config(key = '', value = '')
+        @component_loaded.config[key] = value
+      end
+
+      def ConfigParameter(config_key:, parameter:, defaultValue: '', type: 'String')
+        Parameters do
+          ComponentParam parameter, defaultValue, type: type
+        end
+        config config_key, Ref(parameter)
+      end
+
+      ## for all the message received, try and forward them to load component dsl
+      def method_missing(method, *args, &block)
+        child_dsl = @component_loaded.highlander_dsl
+        if child_dsl.respond_to? method
+          # child_dsl.method
+          child_dsl.send method, *args, &block
+        end
       end
 
       # Parameters should be lazy loaded, that is late-binding should happen once

--- a/lib/cfhighlander.dsl.template.rb
+++ b/lib/cfhighlander.dsl.template.rb
@@ -2,7 +2,7 @@
 
 extensions_folder = "#{File.dirname(__FILE__)}/../hl_ext"
 
-Dir["#{extensions_folder}/*.rb"].each { |f|
+Dir["#{extensions_folder}/*.rb"].each {|f|
   require f
 }
 
@@ -56,8 +56,10 @@ module Cfhighlander
         @dependson_components_templates = []
         @dependson_components = []
         @conditions = []
-        @config_overrides = {},
+        @config_overrides = {}
         @extended_template = nil
+        # execution blocks for subcomponents
+        @subcomponents_exec = {}
       end
 
       # DSL statements
@@ -84,8 +86,12 @@ module Cfhighlander
 
       def Parameters(&block)
         @parameters.config = @config
-        @parameters.instance_eval(&block)
+        @parameters.instance_eval(&block) unless block.nil?
       end
+
+      # def ComponentParam(argc*, argv)
+      #   @parameters.ComponentParam(argc, argv)
+      # end
 
       def Condition(name, expression)
         @conditions << Condition.new(name, expression)
@@ -93,7 +99,7 @@ module Cfhighlander
 
       def DynamicMappings(providerName)
         maps = mappings_provider_maps(providerName, self.config)
-        maps.each { |name, map| addMapping(name, map) } unless maps.nil?
+        maps.each {|name, map| addMapping(name, map)} unless maps.nil?
       end
 
       def DependsOn(template)
@@ -133,7 +139,8 @@ module Cfhighlander
             conditional,
             enabled
         )
-        component.instance_eval(&block) unless block.nil?
+        # component.instance_eval(&block) unless block.nil?
+        @subcomponents_exec[name] = block unless block.nil?
         component.distribute_bucket = @distribution_bucket unless @distribution_bucket.nil?
         component.distribute_prefix = @distribution_prefix unless @distribution_prefix.nil?
         component.version = @version unless @version.nil?
@@ -188,11 +195,11 @@ module Cfhighlander
 
       # Internal and interface functions
 
-      def loadComponents()
+      def loadComponents
 
         # empty config overrides to start with
-        @config_overrides = Hash[@subcomponents.collect { |c| [c.name, { 'nested_component' => true }] }]
-        @named_components = Hash[@subcomponents.collect { |c| [c.name, c] }]
+        @config_overrides = Hash[@subcomponents.collect {|c| [c.name, { 'nested_component' => true }]}]
+        @named_components = Hash[@subcomponents.collect {|c| [c.name, c]}]
 
         # populate overrides with master config defined overrides
         load_configfile_component_config
@@ -217,6 +224,7 @@ module Cfhighlander
         @subcomponents.each do |component|
 
           component.load @config_overrides[component.name]
+
           # add all of it's stack parameters unless same template has been already processed
           component
               .component_loaded
@@ -241,8 +249,10 @@ module Cfhighlander
             end
 
           end
-
-          component.component_loaded.eval_cfndsl()
+          if @subcomponents_exec.key? component.name
+            component.instance_eval &@subcomponents_exec[component.name]
+          end
+          component.component_loaded.eval_cfndsl
         end
 
         # in 2nd pass, load parameters
@@ -291,14 +301,14 @@ module Cfhighlander
       end
 
       def apply_config_overrides
-        @config_overrides.each { |component_name, component_override|
+        @config_overrides.each {|component_name, component_override|
           @named_components[component_name].component_loaded.config.extend(component_override)
         }
       end
 
       def load_configfile_component_config
         if (@config.key? 'components')
-          @config['components'].each { |component_name, component_config|
+          @config['components'].each {|component_name, component_config|
             if component_config.key?('config')
               if @config_overrides.key? component_name
                 @config_overrides[component_name].extend(component_config['config'])
@@ -313,28 +323,28 @@ module Cfhighlander
       def apply_config_exports
         # first export from master to all children
         if ((@config.key? 'config_export') and (@config['config_export']['global']))
-          @config['config_export']['global'].each { |global_export_key|
+          @config['config_export']['global'].each {|global_export_key|
             if @config.key? global_export_key
-              @config_overrides.each { |cname, co|
+              @config_overrides.each {|cname, co|
                 co[global_export_key] = @config[global_export_key]
               }
             end
           }
         end
 
-        @subcomponents.each { |component|
+        @subcomponents.each {|component|
           cl = component.component_loaded
           if ((not cl.config.nil?) and (cl.config.key? 'config_export'))
 
             # global config
             if cl.config['config_export'].key? 'global'
-              cl.config['config_export']['global'].each { |global_export_key|
+              cl.config['config_export']['global'].each {|global_export_key|
 
                 # global config is exported to parent and every component
                 if cl.config.key? global_export_key
 
                   # cname is for component name, co for component override
-                  @config_overrides.each { |cname, co|
+                  @config_overrides.each {|cname, co|
 
                     # if templates are different e.g don't export from vpc to vpc
                     config_receiver_component = @named_components[cname]
@@ -360,7 +370,7 @@ module Cfhighlander
             end
 
             if cl.config['config_export'].key? 'component'
-              cl.config['config_export']['component'].each { |component_name, export_keys|
+              cl.config['config_export']['component'].each {|component_name, export_keys|
                 # check if there is configuration of export from this component
                 # and if there is export configuration for given component name
 
@@ -369,7 +379,7 @@ module Cfhighlander
                   if @config_overrides.key? component.export_config[component_name]
                     # override the config
                     real_component_name = component.export_config[component_name]
-                    export_keys.each { |export_component_key|
+                    export_keys.each {|export_component_key|
                       puts("Exporting config for key=#{export_component_key} from #{component.name} to #{real_component_name}")
                       if not @config_overrides[real_component_name].key? export_component_key
                         @config_overrides[real_component_name][export_component_key] = {}
@@ -380,7 +390,7 @@ module Cfhighlander
                     STDERR.puts("Trying to export configuration for non-existant component #{component.export_config[component_name]}")
                   end
                 elsif @config_overrides.key? component_name
-                  export_keys.each { |export_component_key|
+                  export_keys.each {|export_component_key|
                     puts("Exporting config for key=#{export_component_key} from #{component.name} to #{component_name}")
                     if not @config_overrides[component_name].key? export_component_key
                       @config_overrides[component_name][export_component_key] = {}
@@ -400,7 +410,7 @@ module Cfhighlander
       end
 
       def load_explicit_component_config
-        @component_configs.each { |component_name, component_config|
+        @component_configs.each {|component_name, component_config|
           @config_overrides[component_name].extend(component_config)
         }
 
@@ -424,7 +434,7 @@ module Cfhighlander
         if not (@distribution_bucket.nil? or @distribution_prefix.nil?)
           @distribute_url = "https://#{@distribution_bucket}.s3.amazonaws.com/#{@distribution_prefix}"
           @distribute_url = "#{@distribute_url}/#{@version}" unless @version.nil?
-          @subcomponents.each { |component|
+          @subcomponents.each {|component|
             component.distribute_bucket = @distribution_bucket unless @distribution_bucket.nil?
             component.distribute_prefix = @distribution_prefix unless @distribution_prefix.nil?
             component.version = @version unless @version.nil?
@@ -472,12 +482,15 @@ def CfhighlanderTemplate(&block)
   unless @distribution_prefix.nil?
     instance.DistributionPrefix(@distribution_prefix)
   end
+  unless @distribution_format.nil?
+    instance.Forma
+  end
 
   # process convention over configuration componentname.config.yaml files
   @potential_subcomponent_overrides.each do |name, config|
 
     # if there is component with given file name
-    if (not instance.subcomponents.find{|s|s.name == name}.nil?)
+    if (not instance.subcomponents.find {|s| s.name == name}.nil?)
       instance.config['components'] = {} unless instance.config.key? 'components'
       instance.config['components'][name] = {} unless instance.config['components'].key? name
       instance.config['components'][name]['config'] = {} unless instance.config['components'][name].key? 'config'
@@ -486,7 +499,7 @@ def CfhighlanderTemplate(&block)
       if config.key? 'components'
         if config['components'].key? name
           if config['components'][name].key? 'config'
-           config = config['components'][name]['config']
+            config = config['components'][name]['config']
           end
         end
       end

--- a/lib/util/zip.util.rb
+++ b/lib/util/zip.util.rb
@@ -17,7 +17,7 @@ module Cfhighlander
       # Zip the input directory.
       def write
         entries = Dir.entries(@input_dir) - %w(. ..)
-
+        puts "DEBUG: Compressing #{@input_dir} to #{@output_file}"
         ::Zip::File.open(@output_file, ::Zip::File::CREATE) do |zipfile|
           write_entries entries, '', zipfile
         end
@@ -30,7 +30,6 @@ module Cfhighlander
         entries.each do |e|
           zipfile_path = path == '' ? e : File.join(path, e)
           disk_file_path = File.join(@input_dir, zipfile_path)
-          puts "TRACE: Deflating #{disk_file_path}"
 
           if File.directory? disk_file_path
             recursively_deflate_directory(disk_file_path, zipfile, zipfile_path)


### PR DESCRIPTION
### Features

1. This PR should enable cfhighlander develop to use cloudformation functions in highlander templates, such as `Fn::FindInMap` and `Fn::GetAtt`. Using `cfndsl` syntax is supported (e.g. `FnFindInMap`, as well as syntax proposed in parameter refactoring #8 .  It adds `ConfigParameter` dsl statement available in `Component` context, effectively allowing component consumer to pass stack parameter as configuration value. This avoids need for changing component code when dynamic behaviour of parameter is required.  

```ruby
CfhighlanderTemplate do
  Component 'myapp' do 
    # replaces just string 'component.Output' - though this will still work as legacy
    parameter name: 'CognitoPoolArn', value: cfout('cognito.UserPoolArn')   
    # different syntax having same effect as line above
    parameter name: 'CognitoPoolArn2', value: cfout('cognito2','UserPoolArn')  

     
    # use cfmap to pass mapping parameters. Ref('') function same as in cfndsl is 
    # also supported 
    parameter name: 'Az0', value: cfmap(
      Ref('AWS::AccountId'), 
      Ref('AWS::Region'),
      'Az0'
    )

    # this is new construct, effectively replacing configuration value with 
    # top level parameter
    ConfigParameter config_key: 'app_version', parameter: 'ApplicationVersion'

    # if you are familiar with cfndsl following syntax is possible, as alias 
    # to cfmap
    parameter name: 'ImageId', value: FnFindInMap('AMIS','myapp','ImageId')
    parameter name: 'BastionId', value: FindInMap('AMIS','bastion','ImageId')

    # read properties of resources within component with FnGetAtt or just GetAtt
    parameter name: 'Feature1Enabled', value: FnGetAtt('S3JsonFile','Feature1Enabled')
    parameter name: 'Feature1Enabled', value: GetAtt('S3JsonFile','Feature1Enabled')

    
  end
end
```

### Bugs fixed
- Lambda temporary packaging directory is being cleaned up before packaging

