### PR TITLE
Fix lambda extend

### DIFF
--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -3,7 +3,7 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'cfhighlander'
-  s.version = '0.3.1'
+  s.version = '0.4.0'
   s.version = "#{s.version}.alpha.#{Time.now.getutc.to_i}" if ENV['TRAVIS'] and ENV['TRAVIS_BRANCH'] != 'master'
   s.date = Date.today.to_s
   s.summary = 'DSL on top of cfndsl. Manage libraries of cloudformation components'

--- a/cfndsl_ext/lambda_helper.rb
+++ b/cfndsl_ext/lambda_helper.rb
@@ -61,6 +61,9 @@ def render_lambda_functions(cfndsl, lambdas, lambda_metadata, distribution)
           FunctionName(Ref(name))
           Action('lambda:InvokeFunction')
           Principal(source['principal'])
+          if source.key? 'source_arn'
+            SourceArn source['source_arn']
+          end
         end
         i += 1
       end

--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -174,7 +174,7 @@ module Cfhighlander
         if not @parent_template.nil?
           extended_component = @factory.loadComponentFromTemplate(@parent_template)
           extended_component.is_parent_component = true
-          extended_component.load()
+          extended_component.load(@config)
 
           @config = extended_component.config.extend(@config)
           @mappings = extended_component.mappings.extend(@mappings)


### PR DESCRIPTION
## Bugfixes

`Extends` dsl method did not work for source code of lambda packages. Any source code from parent was shadowed by extending component. With this PR it is possible to point to source code for lambda functions both from parent, and from extending component. 

## Improvements

Usage of `source_arn` is possible for lambda permissions configuration. Aside from service, it is possible to point to actual event source. 

