### PR TITLE
Turn key distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ via CLI (`--dstbucket`, `--dstprefix`, `-v`). Default distribution bucket and pr
 `DistributionBucket`, `DistributionBucket`, `DistributionPrefix` or `ComponentDistribution` statements. Check DSL specification
 for more details on this statements. Version defaults to `latest` if not explicitly given using `-v` switch
 
+If no distribution options is given using mentioned CLI options or DSL statements,
+bucket will be automatically created for you. Bucket name defaults to 
+`$ACCOUNT.$REGION.cfhighlander.templates`, with `/published-templates`
+prefix. 
+
+*cfpublish* command will give you quick launch CloudFirmation stack URL to assist
+you in creating your stack:
+
+```bash
+$ cfpublish vpc@1.2.0
+...
+...
+...
+
+Use following url to launch CloudFormation stack
+
+https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?filter=active&templateURL=https://123456789012.ap-southeast-2.cfhighlander.templates.s3.amazonaws.com/published-templates/vpc/1.2.0/vpc.compiled.yaml&stackName=vpc
+
+```
+
 
 #### configcompile
 

--- a/hl_ext/aws_helper.rb
+++ b/hl_ext/aws_helper.rb
@@ -1,7 +1,19 @@
 require 'aws-sdk-s3'
+require 'aws-sdk-ec2'
 
 def aws_credentials
   # TODO implement credentials e.g. for environment create/update/delete
+end
+
+def aws_account_id()
+  sts = Aws::STS::Client.new
+  account = sts.get_caller_identity().account
+  return account
+end
+
+def aws_current_region()
+  region = Aws::EC2::Client.new.describe_availability_zones().availability_zones[0].region_name
+  return region
 end
 
 def s3_bucket_region(bucket)
@@ -10,4 +22,14 @@ def s3_bucket_region(bucket)
   location = 'us-east-1' if location == ''
   location = 'eu-west-1' if location == 'EU'
   location
+end
+
+def s3_create_bucket_if_not_exists(bucket)
+  s3 = Aws::S3::Client.new
+  begin
+    s3.head_bucket(bucket: bucket)
+  rescue
+    puts(" INFO: Creating bucket #{bucket} ")
+    s3.create_bucket(bucket: bucket)
+  end
 end

--- a/lib/cfhighlander.factory.rb
+++ b/lib/cfhighlander.factory.rb
@@ -27,7 +27,7 @@ module Cfhighlander
         raise StandardError, "highlander template #{template_name}@#{template_version} not located" +
             " in sources #{@component_sources}" if template_meta.nil?
 
-        component_name = template_name if component_name.nil?
+        component_name = template_meta.template_name if component_name.nil?
         return buildComponentFromLocation(template_meta, component_name)
 
       end


### PR DESCRIPTION
This PR intends to make `cfpublish` or `cfhighlander cfpublish` command more user-friendly in 2 ways

1. It automatically generates published cloudformation bucket name if none given using CLI options or DSL statements. Bucket name will default to `$ACCOUNT.$REGION.cfhighlander.templates` bucket and `published-templates` prefix

2. Quick launch stack url is shown at end of the output of `cfpublish` command, e.g.

https://asciinema.org/a/iXUY0TNc1fCtRqO6SXmRiW6UD

```shell
$ cfpublish vpc
....
... < cfhl output > 
...

Publishing /private/tmp/out/yaml/vpc.compiled.yaml to s3://334818472548.ap-southeast-2.cfhighlander.templates/published-templates/vpc/1.2.0/vpc.compiled.yaml ... [OK] 


Use following url to launch CloudFormation stack

https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?filter=active&templateURL=https://334818472548.ap-southeast-2.cfhighlander.templates.s3.amazonaws.com/published-templates/vpc/1.2.0/vpc.compiled.yaml&stackName=vpc


```

