### PR TITLE
Fix autogenerate bucket feature

### DIFF
--- a/bin/cfhighlander.rb
+++ b/bin/cfhighlander.rb
@@ -84,7 +84,7 @@ class HighlanderCli < Thor
 
     component = build_component(options, component_name)
 
-    if component.distribution_bucket.nil? or component.distribution_prefix.nil?
+    if component.highlander_dsl.distribution_bucket.nil? or component.highlander_dsl.distribution_prefix.nil?
       component.distribution_bucket="#{aws_account_id()}.#{aws_current_region()}.cfhighlander.templates" if component.distribution_bucket.nil?
       component.distribution_prefix="published-templates/#{component.name}" if component.distribution_prefix.nil?
       puts "INFO: Reloading component, as auto-generated distribution settings  are being applied..."

--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
   s.name = 'cfhighlander'
   s.version = '0.5.0'
   s.version = "#{s.version}.alpha.#{Time.now.getutc.to_i}" if ENV['TRAVIS'] and ENV['TRAVIS_BRANCH'] != 'master'
-  s.date = Date.today.to_s
   s.summary = 'DSL on top of cfndsl. Manage libraries of cloudformation components'
   s.description = ''
   s.authors = [ 'Nikola Tosic', 'Aaron Walker', 'Angus Vine']

--- a/lib/cfhighlander.validator.rb
+++ b/lib/cfhighlander.validator.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk-cloudformation'
 require 'aws-sdk-s3'
 require 'digest/md5'
+require_relative '../hl_ext/aws_helper'
 
 module Cfhighlander
 
@@ -46,6 +47,10 @@ module Cfhighlander
       def validate_s3(path)
         template = File.read path
         bucket = @component.highlander_dsl.distribution_bucket
+        if bucket.nil?
+          bucket = "#{aws_account_id()}.#{aws_current_region()}.cfhighlander.templates"
+          s3_create_bucket_if_not_exists(bucket)
+        end
         prefix = @component.highlander_dsl.distribution_prefix
         md5 = Digest::MD5.hexdigest template
         s3_key = "#{prefix}/highlander/validate/#{md5}"


### PR DESCRIPTION
Autogenerate bucket name (and create if not exists), have been overriding `ComponentDistribution` setting (cli switches are not affected). This is now fixed, and this feature is extended to affect s3 template validation as well. 