### PR TITLE
implicit declaration of subcomponent parameters

### DIFF
--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -128,6 +128,13 @@ module Cfhighlander
       end
 
       def parameter(name:, value:)
+        existing_params = @component_loaded.highlander_dsl.parameters.param_list
+        param_exists = existing_params.find { |p| p.name == name}
+        if (not param_exists)
+          @component_loaded.highlander_dsl.Parameters do
+            ComponentParam name, '', type: 'String'
+          end
+        end
         @param_values[name] = value
       end
 


### PR DESCRIPTION
Allows for adding parameters on inner components dynamically. 
E.g.

```ruby
CfhighlanderTemplate do
      Component 'ecs-service' do 
           parameter name:'version',  value: FnFindInMap('containertags','app',Ref('EnvironmentName'))
      end
do
```