### PR TITLE
allow either array or string of trusted services

### DIFF
--- a/cfndsl_ext/iam_helper.rb
+++ b/cfndsl_ext/iam_helper.rb
@@ -1,10 +1,17 @@
-def service_role_assume_policy(service)
-  unless service.end_with? '.amazonaws.com'
-    service = "#{service}.amazonaws.com"
+def service_role_assume_policy(services)
+
+  services = (services.kind_of?(Array) ? services : [services])
+  statement = []
+
+  services.each do |service|
+    unless service.end_with? '.amazonaws.com'
+      service = "#{service}.amazonaws.com"
+    end
+    statement << { Effect: 'Allow', Principal: { Service: "#{service}" }, Action: 'sts:AssumeRole' }
   end
   return {
       Version: '2012-10-17',
-      Statement: [{ Effect: 'Allow', Principal: { Service: "#{service}" }, Action: 'sts:AssumeRole' }]
+      Statement: statement
   }
 end
 


### PR DESCRIPTION
Config
```yaml
iam_assumed_services:
  - ec2
  - ssm
```
with function
```ruby
  Role('Role') do
    puts trusted_services
    AssumeRolePolicyDocument service_role_assume_policy(iam_assumed_services)
    Path '/'
    Policies(policies)
  end
```

Produces
```yaml
  Role:
    Properties:
      AssumeRolePolicyDocument:
        Version: '2012-10-17'
        Statement:
        - Effect: Allow
          Principal:
            Service: ec2.amazonaws.com
          Action: sts:AssumeRole
      Path: "/"
      Policies:
```