### PR TITLE
fix up flatten test. bug fix with output renames

### DIFF
--- a/lib/cfhighlander.compiler.rb
+++ b/lib/cfhighlander.compiler.rb
@@ -171,8 +171,7 @@ module Cfhighlander
         # `cfndsl #{@cfndsl_compiled_path} -p -f #{format} -o #{output_path} --disable-binding`
         puts "CloudFormation #{format.upcase} template for #{dsl.name} written to #{output_path}"
 
-
-
+        return JSON.parse(model.to_json)
 
       end
 

--- a/lib/util/cloudformation.util.rb
+++ b/lib/util/cloudformation.util.rb
@@ -94,6 +94,12 @@ module Cfhighlander
         inline_elements('Conditions', component, template)
         inline_elements('Mappings', component, template)
         inline_elements('Resources', component, template)
+
+        # outputs are renamed AFTER all of the other processing
+        # has been done, as outputs are referenced. Only
+        # outputs of inlined components are renamed
+        flatten_namespace('Outputs', component, template)
+        Debug.debug_dump_cfn(template, 'flat.outputs')
         inline_elements('Outputs', component, template)
       end
 
@@ -364,7 +370,7 @@ module Cfhighlander
       def self.rename_mapping(tree, search, replacement)
         tree.keys.each do |k|
           v = tree[k]
-          if k == 'Fn::FindInMap' and v[0] = search
+          if k == 'Fn::FindInMap' and v[0] == search
             tree[k] = [replacement, v[1], v[2]]
           end
 
@@ -440,9 +446,6 @@ module Cfhighlander
 
         flatten_namespace('Resources', component, template)
         Debug.debug_dump_cfn(template, 'flat.resources')
-
-        flatten_namespace('Outputs', component, template)
-        Debug.debug_dump_cfn(template, 'flat.outputs')
       end
 
     end

--- a/spec/data/flatten/src/c.cfhighlander.rb
+++ b/spec/data/flatten/src/c.cfhighlander.rb
@@ -11,7 +11,7 @@ CfhighlanderTemplate do
   Component template: 'c1', name: 'c1a', render: Inline
   Component template: 'c1', name: 'c1b', render: Inline
 
-  Component 'c2' do
+  Component template:'c2',name:'c2', render: Inline do
     parameter name: 'c1OutParam', value: FnIf('UseC1',
         cfout('c1a.c1OutParam'),
         cfout('c1b.c1OutParam')

--- a/spec/test_cloudformation_util_spec.rb
+++ b/spec/test_cloudformation_util_spec.rb
@@ -5,7 +5,7 @@ require 'pp'
 require 'octokit'
 require 'rspec'
 
-RSpec.describe Cfhighlander::Util::CloudformationUtil, "#flattenCloudformation" do
+RSpec.describe Cfhighlander::Util::CloudFormation, "#flattenCloudformation" do
 
   context "test cloudformation inllining" do
     it "flattens cloudformation" do
@@ -19,11 +19,10 @@ RSpec.describe Cfhighlander::Util::CloudformationUtil, "#flattenCloudformation" 
       component.eval_cfndsl
 
       compiler = Cfhighlander::Compiler::ComponentCompiler.new(component)
-      compiler.compileCloudFormation
+      model_flat = compiler.compileCloudFormation
 
-      model_flat = Cfhighlander::Util::CloudformationUtil.flattenCloudformation(component:component)
-      model_flat = JSON.parse(model_flat.to_json)
       model_flat_expected =  YAML.load(File.read("#{src_dir}/../c.compiled.flat.yaml"))
+      FileUtils.mkdir_p "#{File.dirname(__FILE__)}/../test"
       File.write "#{File.dirname(__FILE__)}/../test/c.flat.yaml", model_flat.to_yaml
 
       expect(model_flat).to eq(model_flat_expected)


### PR DESCRIPTION
## Tests

`Problem`  as @benleov noted, test for inlining are not actually being ran during `rspec` as the file name needs to end in `spec.rb`

## Bug Fix

If 2 components of same template were inlined, 2nd component's outputs would be renamed BEFORE flattening is executed. This renders in all outer references to this output value invalid. Luckily, this was included in cf flattening tests. 


