### PR TITLE
multilevel config files

### DIFF
--- a/lib/cfhighlander.config.loader.rb
+++ b/lib/cfhighlander.config.loader.rb
@@ -1,0 +1,34 @@
+require_relative '../hl_ext/common_helper'
+
+module Cfhighlander
+
+  module Config
+
+    class Loader
+      # creates top-level component configuration
+      # for component.subcomponent.subsubcomponent.....config.yaml
+      # configuration file
+      # method allows for N-level configuration (no limitation on level)
+      #  parameters
+      #     component_location: component in hierarchy e.g. app.db.rds
+      #     config: actual component configuration
+      def get_nested_config(component_location, config)
+        parts = component_location.split('.')
+        i = 0
+        current_config = Hash.new
+        rval = current_config
+        while i < parts.size
+          current_config['components'] = Hash.new
+          component_name = parts[i]
+          current_config['components'][component_name] = { 'config' => Hash.new }
+          current_config = current_config['components'][component_name]['config']
+          i = i+1
+        end
+        current_config.extend config
+        return rval
+      end
+
+    end
+
+  end
+end

--- a/lib/cfhighlander.dsl.template.rb
+++ b/lib/cfhighlander.dsl.template.rb
@@ -11,6 +11,7 @@ Dir["#{extensions_folder}/*.rb"].each {|f|
 require_relative './cfhighlander.dsl.base'
 require_relative './cfhighlander.dsl.params'
 require_relative './cfhighlander.dsl.subcomponent'
+require_relative './cfhighlander.config.loader'
 
 module Cfhighlander
 
@@ -486,10 +487,13 @@ def CfhighlanderTemplate(&block)
   end
 
   # process convention over configuration componentname.config.yaml files
+  config_loader = Cfhighlander::Config::Loader.new
+
   @potential_subcomponent_overrides.each do |name, config|
 
     # if there is component with given file name
-    if (not instance.subcomponents.find {|s| s.name == name}.nil?)
+    first_component = name.split('.').first
+    if (not instance.subcomponents.find { |s| s.name == first_component }.nil?)
       instance.config['components'] = {} unless instance.config.key? 'components'
       instance.config['components'][name] = {} unless instance.config['components'].key? name
       instance.config['components'][name]['config'] = {} unless instance.config['components'][name].key? 'config'
@@ -503,8 +507,7 @@ def CfhighlanderTemplate(&block)
           end
         end
       end
-
-      instance.config['components'][name]['config'].extend config
+      instance.config.extend(config_loader.get_nested_config(name, config))
     end
   end
 

--- a/lib/cfhighlander.version.rb
+++ b/lib/cfhighlander.version.rb
@@ -1,3 +1,3 @@
 module Cfhighlander
-  VERSION="0.8.1".freeze
+  VERSION="0.8.2".freeze
 end

--- a/spec/test_config_loader.rb
+++ b/spec/test_config_loader.rb
@@ -1,0 +1,53 @@
+require_relative '../lib/cfhighlander.config.loader'
+
+RSpec.describe Cfhighlander::Config::Loader, "#get_nested_config" do
+
+
+  context "nested_config_files" do
+    it "test single level" do
+      loader = Cfhighlander::Config::Loader.new
+      nested_config = loader.get_nested_config('a', { 'key' => 'value' })
+      expected_component_config = {
+          'components' => {
+              'a' => {
+                  'config' => { 'key' => 'value' }
+              }
+          }
+      }
+      expect(nested_config).to eq(expected_component_config)
+    end
+    it "test_config_4_levels_deep" do
+      loader = Cfhighlander::Config::Loader.new
+      nested_config = loader.get_nested_config('a.b.c.d', { 'key' => 'value' })
+      expected_nested_config = {
+          'components' => {
+              'a' => {
+                  'config' => {
+                      'components' => {
+                          'b' => {
+                              'config' => {
+                                  'components' => {
+                                      'c' => {
+                                          'config' => {
+                                              'components' => {
+                                                  'd' => {
+                                                      'config' => {
+                                                          'key' => 'value'
+                                                      }
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+      expect(nested_config).to eq(expected_nested_config)
+    end
+  end
+
+end


### PR DESCRIPTION
## What

Implementation of one of the solutions for problem described in #92 

Every config file in component root can be of format `component.subcomponent.subsubcomponent......config.yaml` to target sub-component on a specific level in hierarchy. 

## Testing

Implementation is done with TDD approach, with tests/rspec written first. All of the components are compiling against this - https://travis-ci.com/toshke/cfhighlander/builds/1017692921  (no Azure Devops yet ;))

Also, @Guslington usecase is tested and has been used for demo functionality repository here - https://github.com/toshke/cfhighlander-nestedconfig-demo
