### PR TITLE
dependency updates

### DIFF
--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'highline', '>=1.7.10','<1.8'
   s.add_runtime_dependency 'thor', '~>0.20', '<1'
-  s.add_runtime_dependency 'cfndsl', '~>0.17', '<1'
+  s.add_runtime_dependency 'cfndsl', '0.17.2'
   s.add_runtime_dependency 'rubyzip', '>=1.2.1', '<2'
   s.add_runtime_dependency 'aws-sdk-core', '~> 3','<4'
   s.add_runtime_dependency 'aws-sdk-s3', '~> 1', '<2'
   s.add_runtime_dependency 'aws-sdk-ec2', '~> 1', '<2'
   s.add_runtime_dependency 'aws-sdk-cloudformation', '~> 1', '<2'
   s.add_runtime_dependency 'git', '~> 1.4', '<2'
-  s.add_runtime_dependency 'netaddr', '~> 1.5', '>= 1.5.1'
+  s.add_runtime_dependency 'netaddr', '>= 2.0.4', '<3'
   s.add_runtime_dependency 'duplicate','~> 1.1'
   s.add_development_dependency 'rspec', '~> 3.7'
 end


### PR DESCRIPTION
@toshke removing netaddr as there was a security issue with the version we had, but i couldn't see it being used. Do you know if it's still required?

https://github.com/theonestack/cfhighlander/network/alert/cfhighlander.gemspec/netaddr/open

Also bumping cfndsl to 0.17.4 due to a compatibility issue with cfndsl 0.17.3 and cfhighlander cause we are not utilising the `external_parameter` method to pass in variables. However there was a fix in 0.17.4 to resolve the issue. https://github.com/cfndsl/cfndsl/issues/422