### PR TITLE
expose component path via a environment variable

### DIFF
--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -109,8 +109,10 @@ module Cfhighlander
         if File.exist? legacy_cfhighlander_path
           STDERR.puts "DEPRECATED: #{legacy_cfhighlander_path} - Use *.cfhighlander.rb"
           @highlander_dsl_path = legacy_cfhighlander_path
+          ENV['CF_COMPONENT_PATH'] = @component_dir
         else
           @highlander_dsl_path = "#{@component_dir}/#{@template.template_name}.cfhighlander.rb"
+          ENV['CF_COMPONENT_PATH'] = @component_dir
         end
 
         @cfndsl_path = "#{@component_dir}/#{@template.template_name}.cfndsl.rb"


### PR DESCRIPTION
Allow a cftemplate to consume extension libraries

```ruby
require "#{ENV['CF_COMPONENT_PATH']}/ext/cfndsl/subnets"

CfhighlanderTemplate do
  Name 'vpc-v2'
```

@toshke unless you can think of a better way?