### PR TITLE
handle passing CommaDelimitedList parameters through to nested stacks

### DIFF
--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -283,6 +283,13 @@ module Cfhighlander
         propagated_param.name = "#{sub_component.cfn_name}#{param.name}" unless param.is_global
         component.parameters.addParam propagated_param
         puts " no autowiring candidates, propagate parameter to parent"
+        
+        if param.type == 'CommaDelimitedList'
+          return CfnDsl::Fn.new('Join', [',',
+            CfnDsl::RefDefinition.new(propagated_param.name)
+          ]).to_json
+        end
+        
         return CfnDsl::RefDefinition.new(propagated_param.name).to_json
 
       end


### PR DESCRIPTION
If the parameter type is `CommaDelimitedList` this cannot be passed directly into a nested stack parameter. It has to be wrapped in a fn::join