### PR TITLE
disable cfndsl binding with an option to enable for legacy components

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,26 @@ test_metadata:
   description: Create 2 queues with name and override available config
 ```
 
+### Test Paramaters
+
+If you want to test a component with a parameter input you can specify the `test-parameters:` key with key:value pairs of parameters
+
+```yaml
+# Define the test parameter
+test_parameters:
+  SecurityGroupId: sg-123456789
+
+# Test configuration
+security_group_rules:
+  -
+    from: 22
+    protocol: tcp
+    security_group_id:
+      # use the parameter within our test
+      Ref: SecurityGroupId
+    desc: ssh access from another security group
+```
+
 ### Running Test
 
 ```bash

--- a/bin/cfhighlander.rb
+++ b/bin/cfhighlander.rb
@@ -54,7 +54,9 @@ class HighlanderCli < Thor
       :enum => %w(yaml json), :desc => 'CloudFormation templates output format'
   method_option :quiet, :type => :boolean, :default => false, :aliases => '-q',
       :desc => 'Silently agree on user prompts (e.g. Package lambda command)'
-
+  method_option :cfndsl_binding, :type => :boolean, :default => false, :aliases => '-b',
+      :desc => 'Enables the legacy cfndsl binding for component configuration'
+          
   def dslcompile(component_name)
     component = build_component(options, component_name)
 
@@ -62,6 +64,7 @@ class HighlanderCli < Thor
     component_compiler = Cfhighlander::Compiler::ComponentCompiler.new(component)
     component_compiler.clear_out_dir
     component_compiler.silent_mode = options[:quiet]
+    component_compiler.cfndsl_binding = options[:cfndsl_binding]
     out_format = options[:format]
     component_compiler.compileCfnDsl out_format
   end
@@ -80,7 +83,9 @@ class HighlanderCli < Thor
       :desc => 'Optionally validate template'
   method_option :quiet, :type => :boolean, :default => false, :aliases => '-q',
       :desc => 'Silently agree on user prompts (e.g. Package lambda command)'
-
+  method_option :cfndsl_binding, :type => :boolean, :default => false, :aliases => '-b',
+      :desc => 'Enables the legacy cfndsl binding for component configuration'
+          
   def cfcompile(component_name = nil, autogenerate_dist = false)
 
     if component_name.nil?
@@ -106,6 +111,7 @@ class HighlanderCli < Thor
     component_compiler = Cfhighlander::Compiler::ComponentCompiler.new(component)
     component_compiler.clear_out_dir
     component_compiler.silent_mode = options[:quiet]
+    component_compiler.cfndsl_binding = options[:cfndsl_binding]
     out_format = options[:format]
     component_compiler.compileCloudFormation out_format
     if options[:validate]
@@ -129,6 +135,8 @@ class HighlanderCli < Thor
       :desc => 'Optionally validate template'
   method_option :quiet, :type => :boolean, :default => false, :aliases => '-q',
       :desc => 'Silently agree on user prompts (e.g. Package lambda command)'
+  method_option :cfndsl_binding, :type => :boolean, :default => false, :aliases => '-b',
+      :desc => 'Enables the legacy cfndsl binding for component configuration'
 
   def cfpublish(component_name)
     compiler = cfcompile(component_name, true)

--- a/bin/cfhighlander.rb
+++ b/bin/cfhighlander.rb
@@ -215,6 +215,10 @@ class HighlanderCli < Thor
         puts "INFO: Reloading component, as auto-generated distribution settings  are being applied..."
         component.load
       end if autogenerate_dist
+      
+      test[:test_parameters].each do |name,value|
+        component.highlander_dsl.parameters.ComponentParam(name,value)
+      end
 
       # compile cloud formation
       component_compiler = Cfhighlander::Compiler::ComponentCompiler.new(component)

--- a/bin/cfhighlander.rb
+++ b/bin/cfhighlander.rb
@@ -54,8 +54,7 @@ class HighlanderCli < Thor
       :enum => %w(yaml json), :desc => 'CloudFormation templates output format'
   method_option :quiet, :type => :boolean, :default => false, :aliases => '-q',
       :desc => 'Silently agree on user prompts (e.g. Package lambda command)'
-  method_option :cfndsl_binding, :type => :boolean, :default => false, :aliases => '-b',
-      :desc => 'Enables the legacy cfndsl binding for component configuration'
+
           
   def dslcompile(component_name)
     component = build_component(options, component_name)
@@ -64,7 +63,6 @@ class HighlanderCli < Thor
     component_compiler = Cfhighlander::Compiler::ComponentCompiler.new(component)
     component_compiler.clear_out_dir
     component_compiler.silent_mode = options[:quiet]
-    component_compiler.cfndsl_binding = options[:cfndsl_binding]
     out_format = options[:format]
     component_compiler.compileCfnDsl out_format
   end
@@ -83,8 +81,6 @@ class HighlanderCli < Thor
       :desc => 'Optionally validate template'
   method_option :quiet, :type => :boolean, :default => false, :aliases => '-q',
       :desc => 'Silently agree on user prompts (e.g. Package lambda command)'
-  method_option :cfndsl_binding, :type => :boolean, :default => false, :aliases => '-b',
-      :desc => 'Enables the legacy cfndsl binding for component configuration'
           
   def cfcompile(component_name = nil, autogenerate_dist = false)
 
@@ -111,7 +107,6 @@ class HighlanderCli < Thor
     component_compiler = Cfhighlander::Compiler::ComponentCompiler.new(component)
     component_compiler.clear_out_dir
     component_compiler.silent_mode = options[:quiet]
-    component_compiler.cfndsl_binding = options[:cfndsl_binding]
     out_format = options[:format]
     component_compiler.compileCloudFormation out_format
     if options[:validate]
@@ -135,8 +130,6 @@ class HighlanderCli < Thor
       :desc => 'Optionally validate template'
   method_option :quiet, :type => :boolean, :default => false, :aliases => '-q',
       :desc => 'Silently agree on user prompts (e.g. Package lambda command)'
-  method_option :cfndsl_binding, :type => :boolean, :default => false, :aliases => '-b',
-      :desc => 'Enables the legacy cfndsl binding for component configuration'
 
   def cfpublish(component_name)
     compiler = cfcompile(component_name, true)

--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'highline', '>=1.7.10','<1.8'
   s.add_runtime_dependency 'thor', '~>0.20', '<1'
-  s.add_runtime_dependency 'cfndsl', '0.17.2'
+  s.add_runtime_dependency 'cfndsl', '>=0.17.5', '<1'
   s.add_runtime_dependency 'rubyzip', '>=2.0.0', '<3'
   s.add_runtime_dependency 'aws-sdk-core', '~> 3','<4'
   s.add_runtime_dependency 'aws-sdk-s3', '~> 1', '<2'

--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'highline', '>=1.7.10','<1.8'
   s.add_runtime_dependency 'thor', '~>0.20', '<1'
-  s.add_runtime_dependency 'cfndsl', '1.0.0.pre.1'
+  s.add_runtime_dependency 'cfndsl', '~> 1', '<2'
   s.add_runtime_dependency 'rubyzip', '>=2.0.0', '<3'
   s.add_runtime_dependency 'aws-sdk-core', '~> 3','<4'
   s.add_runtime_dependency 'aws-sdk-s3', '~> 1', '<2'

--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'highline', '>=1.7.10','<1.8'
   s.add_runtime_dependency 'thor', '~>0.20', '<1'
-  s.add_runtime_dependency 'cfndsl', '>=0.17.5', '<1'
+  s.add_runtime_dependency 'cfndsl', '1.0.0.pre.1'
   s.add_runtime_dependency 'rubyzip', '>=2.0.0', '<3'
   s.add_runtime_dependency 'aws-sdk-core', '~> 3','<4'
   s.add_runtime_dependency 'aws-sdk-s3', '~> 1', '<2'

--- a/cfndsl_ext/lambda_helper.rb
+++ b/cfndsl_ext/lambda_helper.rb
@@ -50,7 +50,9 @@ def render_lambda_functions(cfndsl, lambdas, lambda_metadata, distribution)
         end
       end
     end
-
+    
+    puts "\n\nI AM HERE\n\n"
+    
     Lambda_Version("#{name}Version#{lambda_metadata['version'][key]}") do
       DeletionPolicy('Retain')
       FunctionName(Ref(name))

--- a/lib/cfhighlander.compiler.rb
+++ b/lib/cfhighlander.compiler.rb
@@ -37,6 +37,7 @@ module Cfhighlander
 
         @workdir = ENV['CFHIGHLANDER_WORKDIR']
         @component = component
+        @cfndsl_binding = false
         @sub_components = []
         @component_name = component.highlander_dsl.name.downcase
         @cfndsl_compiled = false
@@ -74,6 +75,11 @@ module Cfhighlander
       def silent_mode=(value)
         @silent_mode = value
         @sub_components.each { |scc| scc.silent_mode = value }
+      end
+      
+      def cfndsl_binding=(value)
+        @cfndsl_binding = value
+        @sub_components.each { |scc| scc.cfndsl_binding = value }
       end
 
       def compileCfnDsl(out_format)
@@ -123,7 +129,8 @@ module Cfhighlander
         # write config
         cfndsl_opts = []
         cfndsl_opts.push([:yaml, @config_yaml_path])
-
+        
+        CfnDsl.disable_binding unless @cfndsl_binding
         # grab cfndsl model
         model = CfnDsl.eval_file_with_extras(@cfndsl_compiled_path, cfndsl_opts, false)
         @cfn_model = model

--- a/lib/cfhighlander.compiler.rb
+++ b/lib/cfhighlander.compiler.rb
@@ -130,7 +130,6 @@ module Cfhighlander
         cfndsl_opts = []
         cfndsl_opts.push([:yaml, @config_yaml_path])
         
-        CfnDsl.disable_binding unless @cfndsl_binding
         # grab cfndsl model
         model = CfnDsl.eval_file_with_extras(@cfndsl_compiled_path, cfndsl_opts, false)
         @cfn_model = model

--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -241,9 +241,6 @@ module Cfhighlander
       end
       def eval_cfndsl
         compiler = Cfhighlander::Compiler::ComponentCompiler.new self
-        # there is no need for processing lambda source code during cloudformation evaluation,
-        # this version never gets published
-        compiler.process_lambdas = false
         @cfn_model = compiler.evaluateCloudFormation().as_json
         @cfn_model_raw = JSON.parse(@cfn_model.to_json)
         @outputs = (

--- a/lib/cfhighlander.tests.rb
+++ b/lib/cfhighlander.tests.rb
@@ -28,7 +28,13 @@ module CfHighlander
     def get_cases
       @test_files.each do |file|
         test_case = load_test_case(file)
-        @cases << { metadata: test_case['test_metadata'], file: file, config: load_default_config.deep_merge(test_case) }
+        test_parameters = test_case['test_parameters'] || {}
+        @cases << { 
+          metadata: test_case['test_metadata'],
+          test_parameters: test_parameters,
+          file: file,
+          config: load_default_config.deep_merge(test_case)
+        }
       end
     end
 

--- a/lib/cfhighlander.version.rb
+++ b/lib/cfhighlander.version.rb
@@ -1,3 +1,3 @@
 module Cfhighlander
-  VERSION="0.11.0".freeze
+  VERSION="0.10.8".freeze
 end

--- a/lib/cfhighlander.version.rb
+++ b/lib/cfhighlander.version.rb
@@ -1,3 +1,3 @@
 module Cfhighlander
-  VERSION="0.10.7".freeze
+  VERSION="0.10.8".freeze
 end

--- a/lib/cfhighlander.version.rb
+++ b/lib/cfhighlander.version.rb
@@ -1,3 +1,3 @@
 module Cfhighlander
-  VERSION="0.10.8".freeze
+  VERSION="0.11.0".freeze
 end

--- a/templates/cfndsl.component.template.erb
+++ b/templates/cfndsl.component.template.erb
@@ -28,8 +28,8 @@ CloudFormation do
     # cfhighlander generated lambda functions
     <% for @key in dsl.lambda_functions_keys %>
         render_lambda_functions(self,
-        <%= @key %>,
-        lambda_metadata,
+        external_parameters[:<%= @key %>],
+        external_parameters[:lambda_metadata],
         {'bucket'=>'<%= dsl.distribution_bucket %>','prefix' => '<%= dsl.distribution_prefix %>', 'version'=>'<%= dsl.version %>'})
     <% end %>
 <% end %>


### PR DESCRIPTION
This PR is so we can update cfndsl and resolve the config eval issue in #121

This will require all component cfndsl templates to be modified to use `external_parameters`

```ruby
tasks.each do |task|
  ...
end
```

is replaced with

```ruby
tasks = external_parameters.fetch(:tasks, [])
tasks.each do |task|
  ...
end
```

This is a breaking change for people using locked components and updating to this version of cfhighlander. There is an option to re enable the cfndsl binding using `-b` but some components still may fail due to the bug described in #121