### PR TITLE
cfndsl 1.0 changes

### DIFF
--- a/cfhighlander.gemspec
+++ b/cfhighlander.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'highline', '>=1.7.10','<1.8'
   s.add_runtime_dependency 'thor', '~>0.20', '<1'
-  s.add_runtime_dependency 'cfndsl', '0.17.2'
+  s.add_runtime_dependency 'cfndsl', '~> 1', '<2'
   s.add_runtime_dependency 'rubyzip', '>=2.0.0', '<3'
   s.add_runtime_dependency 'aws-sdk-core', '~> 3','<4'
   s.add_runtime_dependency 'aws-sdk-s3', '~> 1', '<2'

--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -241,9 +241,6 @@ module Cfhighlander
       end
       def eval_cfndsl
         compiler = Cfhighlander::Compiler::ComponentCompiler.new self
-        # there is no need for processing lambda source code during cloudformation evaluation,
-        # this version never gets published
-        compiler.process_lambdas = false
         @cfn_model = compiler.evaluateCloudFormation().as_json
         @cfn_model_raw = JSON.parse(@cfn_model.to_json)
         @outputs = (

--- a/templates/cfndsl.component.template.erb
+++ b/templates/cfndsl.component.template.erb
@@ -28,8 +28,8 @@ CloudFormation do
     # cfhighlander generated lambda functions
     <% for @key in dsl.lambda_functions_keys %>
         render_lambda_functions(self,
-        <%= @key %>,
-        lambda_metadata,
+        external_parameters[:<%= @key %>],
+        external_parameters[:lambda_metadata],
         {'bucket'=>'<%= dsl.distribution_bucket %>','prefix' => '<%= dsl.distribution_prefix %>', 'version'=>'<%= dsl.version %>'})
     <% end %>
 <% end %>


### PR DESCRIPTION
This PR is so we can update cfndsl and resolve the config eval issue in #121

This will require all component cfndsl templates to be modified to use `external_parameters`

```ruby
tasks.each do |task|
  ...
end
```

is replaced with

```ruby
tasks = external_parameters.fetch(:tasks, [])
tasks.each do |task|
  ...
end
```

This is a breaking change for people using locked components and updating to this version of cfhighlander. There would be no backwards compatibility for older templates not using `external_parameters` as cfndsl 1.0 has removed the binding completely.