### PR TITLE
Update version to 0.11.0

### DIFF
--- a/lib/cfhighlander.version.rb
+++ b/lib/cfhighlander.version.rb
@@ -1,3 +1,3 @@
 module Cfhighlander
-  VERSION="0.10.8".freeze
+  VERSION="0.11.0".freeze
 end


### PR DESCRIPTION
As we are bumping up the version of required cfndsl to 1.0, minor version of cfhighlander gem is updated. We'll raise PR to master subsequently. 