### PR TITLE
Bugfix/silent flag and subcomponents with package command

### DIFF
--- a/lib/cfhighlander.model.component.rb
+++ b/lib/cfhighlander.model.component.rb
@@ -241,6 +241,7 @@ module Cfhighlander
       end
       def eval_cfndsl
         compiler = Cfhighlander::Compiler::ComponentCompiler.new self
+        compiler.lambda_mock_resolve = true
         @cfn_model = compiler.evaluateCloudFormation().as_json
         @cfn_model_raw = JSON.parse(@cfn_model.to_json)
         @outputs = (

--- a/lib/cfhighlander.version.rb
+++ b/lib/cfhighlander.version.rb
@@ -1,3 +1,3 @@
 module Cfhighlander
-  VERSION="0.11.0".freeze
+  VERSION="0.11.1".freeze
 end


### PR DESCRIPTION
## What 

Address https://github.com/theonestack/cfhighlander/issues/142

## Testing

Using following template
```ruby
# app.cfhighlander.rb

CfhighlanderTemplate do
  Component template:'lambdas', name: 'mylambdas', render:Inline
end
```

and 
```ruby
# app2.cfhighlander.rb

CfhighlanderTemplate do
  Component template:'lambdas', name: 'mylambdas', render:Inline
end
```
 
Within https://github.com/theonestack/demo-component-lambdas this repo

## Details

going back in time   `process_lambdas = False` was actually stop gap fix for this bug. While lambdas should be process on component loading for the purposes of evaluating valid cloudformation, there should be no processing of lambda packages as such, as this should come from explicit component compiler, one created in cli entry point. Hence option for dummy values is given - these dummy options will always remain in memory, and never flushed to disk. 