### PR TITLE
Allow passing list type parameters in subcomponents

### DIFF
--- a/lib/cfhighlander.helper.rb
+++ b/lib/cfhighlander.helper.rb
@@ -4,14 +4,19 @@ module Cfhighlander
   module Helper
 
 
-    def self.parameter_cfndsl_value(value)
+    def self.parameter_cfndsl_value(value, nested = false)
 
       if value.class == String
         return "'#{value}'"
       end
 
       if value.class == Hash
+        return value if nested
         return value.to_json
+      end
+
+      if value.class == Array
+        return value.collect { |it| self.parameter_cfndsl_value(it, nested = true) }
       end
 
       return "'#{value}'"


### PR DESCRIPTION
## What

Allow for following construct in outer cfhighlander component - specifying list parameters 

```ruby
# app.cfhighlander.rb
CfhighlanderTemplate do

  Component template: 'simple-vpc', name: 'vpc'

  Component template: 'simple-asg', name: 'asg' do
    parameter name: 'ImageId', value: image_id
    # passing single subnet to ASG SubnetIds list parameter
    parameter name: 'SubnetIds', value: [FnGetAtt('vpc', 'PublicA')]
  end
end

# simple-asg.cfhighlander.rb

CfhighlanderTemplate do
  Parameters do
    ComponentParam 'ImageId', 'ami-08fdde86b93accf1c', type: 'AWS::EC2::Image::Id'
    ComponentParam 'InstanceType', 't3.small'
    # note that SubnetIds are passed in as a list
    ComponentParam 'SubnetIds', type: 'List<AWS::EC2::Subnet::Id>'
    ComponentParam 'VpcId', type: 'AWS::EC2::VPC::Id'
    ComponentParam 'KeyName', type: 'AWS::EC2::KeyPair::KeyName'
  end
end

```

## Testing

```
make test
```