### PR TITLE
template_dir default config, default search locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,16 @@ compiled cloudformation templates). Same CLI / DSL options apply as for *cfpubli
 
 ## Component configuration
 
+### Default configuration values
+
+Within each template, following configuration values are available by default in both cfhl and cfndsl templates
+
+- `template_name` - Name of the cfhighlander template
+- `template_verison` - Version of the cfhighlander component template used
+- `template_dir` - Disk location of the cfhighlander template. Can be used to reference local files within component, and does work with component inheritance
+
+### Defining and overriding configuration
+
 There are 4 levels of component configuration
 
 - Component local config file `component.config.yaml` (lowest priority)

--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -81,7 +81,7 @@ module Cfhighlander
         build_distribution_url
 
         # load component
-        factory = Cfhighlander::Factory::ComponentFactory.new(@component_sources)
+        factory = Cfhighlander::Factory::ComponentFactory.new(@component_sources, parent.template_dir)
         @component_loaded = factory.loadComponentFromTemplate(
             @template,
             @template_version,

--- a/lib/cfhighlander.factory.rb
+++ b/lib/cfhighlander.factory.rb
@@ -13,8 +13,8 @@ module Cfhighlander
 
       attr_accessor :component_sources
 
-      def initialize(component_sources = [])
-        @template_finder = Cfhighlander::Factory::TemplateFinder.new(component_sources)
+      def initialize(component_sources = [], parent_path=nil)
+        @template_finder = Cfhighlander::Factory::TemplateFinder.new(component_sources, parent_path)
         @component_sources = component_sources
       end
 

--- a/lib/cfhighlander.factory.templatefinder.rb
+++ b/lib/cfhighlander.factory.templatefinder.rb
@@ -18,12 +18,13 @@ module Cfhighlander
             File.expand_path('components'),
             File.expand_path('.'),
         ]
-        default_locations.unshift "#{parent_path}components" if parent_path
-        default_locations.unshift parent_path if parent_path
+
         default_locations << ENV['CFHIGHLANDER_WORKDIR'] if ENV.key? 'CFHIGHLANDER_WORKDIR'
         default_locations.each do |predefined_path|
           component_sources.unshift(predefined_path)
         end
+        component_sources.unshift "#{parent_path}/components" if parent_path
+        component_sources.unshift parent_path if parent_path
 
         @component_sources = component_sources
       end

--- a/lib/cfhighlander.factory.templatefinder.rb
+++ b/lib/cfhighlander.factory.templatefinder.rb
@@ -8,8 +8,9 @@ module Cfhighlander
 
     class TemplateFinder
 
-      def initialize(component_sources = [])
-        ## First look in local $PWD/components folder
+      def initialize(component_sources = [], parent_path = nil)
+        ## First look in parent path and it's components folder
+        ## Then look in local $PWD/components folder
         ## Then search for cached $HOME/.highlander/components
         ## Then search in sources given by dsl
         default_locations = [
@@ -17,6 +18,8 @@ module Cfhighlander
             File.expand_path('components'),
             File.expand_path('.'),
         ]
+        default_locations.unshift "#{parent_path}components" if parent_path
+        default_locations.unshift parent_path if parent_path
         default_locations << ENV['CFHIGHLANDER_WORKDIR'] if ENV.key? 'CFHIGHLANDER_WORKDIR'
         default_locations.each do |predefined_path|
           component_sources.unshift(predefined_path)
@@ -97,7 +100,7 @@ module Cfhighlander
           })
           # if code execution got so far we consider file exists and download it locally
           component_files = s3.list_objects_v2({ bucket: bucket, prefix: s3_prefix })
-          component_files.contents.each {|s3_object|
+          component_files.contents.each { |s3_object|
             file_name = s3_object.key.gsub(s3_prefix, '')
             destination_file = "#{local_destination}/#{file_name}"
             destination_dir = File.dirname(destination_file)
@@ -236,6 +239,7 @@ module Cfhighlander
       end
 
       def build_meta(template_name, template_version, template_location)
+        template_location = template_location[0..-2] if template_location.end_with? File::SEPARATOR
         return Cfhighlander::Model::TemplateMetadata.new(
             template_name: template_name,
             template_version: template_version,

--- a/lib/cfhighlander.version.rb
+++ b/lib/cfhighlander.version.rb
@@ -1,3 +1,3 @@
 module Cfhighlander
-  VERSION="0.11.2".freeze
+  VERSION="0.12.0".freeze
 end


### PR DESCRIPTION
## What

- Introduce new default configuration value  `template_dir`, marking physical location of the template. This allows for referencing local files within the template itself. [See here for an example](https://github.com/toshke/cfhl-big-blue-button/blob/WIP/bbb.cfhighlander.rb#L17)

- Add template physical path and `${template_path}/components` as highest priority locations when resolving template name for subcomponents. This allows for component developers to use local template definitions, removing the need for explicit separation into different repositories. See this [big blue button WIP component as an example](https://github.com/toshke/cfhl-big-blue-button/tree/WIP), where `simple-asg` and `simple-vpc` templates are defined within the same repo as `github:toshke/cfhl-big-blue-button` component. 

## Testing

Test functionality with the template below (run `make clean build _local_install` from this branch to build and install gem locally)

```ruby
# file: bbb.cfhighlander.rb
CfhighlanderTemplate do
  Extends 'github:toshke/cfhl-big-blue-button#WIP.snapshot'
end
```

Additionally, avoiding regression by running `make test` 






