### PR TITLE
Makefile docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm cfhighlander-*.gem ; \
     rm -rf /src
 
 RUN adduser -u 1000 -D cfhighlander && \
-    apk add --update python3 git openssh-client bash && \
+    apk add --update python3 git openssh-client bash make && \
     ln $(which pip3) /bin/pip && \
     pip install awscli
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .EXPORT_ALL_VARIABLES:
 
 RUN_RUBY_CMD=docker-compose run --rm -v $$PWD:/src -w /src ruby
-CFHL_DOCKER_TAG ?= latest
+CFHL_DOCKER_TAG ?= $(shell cat lib/cfhighlander.version.rb  | grep VERSION | cut -d '=' -f 2 | sed 's/\.freeze//' | sed 's/"//g')
 
 all: clean build test
 
@@ -23,7 +23,11 @@ test:
 .PHONY: test
 
 buildDocker:
-	docker build -t theonestack/cfhighlander:$(CFHL_DOCKER_TAG) .
+	docker build -t theonestack/cfhighlander:$(CFHL_DOCKER_TAG) -t theonestack/cfhighlander:latest .
+
+pushDocker: buildDocker
+    docker push theonestack/cfhighlander:$(CFHL_DOCKER_TAG)
+    docker push theonestack/cfhighlander:latest
 
 _build:
 	gem build cfhighlander.gemspec


### PR DESCRIPTION
## What

- Docker image version is extracted from `lib/cfhighlander.version.rb`
- Added `dockerPush` target to push  images to docker hub
- `dockerBuild` and `dockerPush` push both latest and version-specific image. 
- `make` available within docker image, supporting 3muskeeter approach in build pipelines. 