### PR TITLE
Replacing some deprecated methods which where removed on Ruby 3.0

### DIFF
--- a/lib/cfhighlander.dsl.subcomponent.rb
+++ b/lib/cfhighlander.dsl.subcomponent.rb
@@ -155,7 +155,7 @@ module Cfhighlander
           param_ovr[:minLength] = minLength unless minLength.nil?
           param_ovr[:minValue] = minValue unless minValue.nil?
           @component_loaded.highlander_dsl.Parameters do
-            ComponentParam name, value, param_ovr
+            ComponentParam name, value, **param_ovr
           end
         else
           parameter.default_value = defaultValue unless defaultValue.nil?

--- a/lib/cfhighlander.publisher.rb
+++ b/lib/cfhighlander.publisher.rb
@@ -1,6 +1,6 @@
 require_relative './cfhighlander.compiler'
 require 'aws-sdk-s3'
-require 'uri'
+
 module Cfhighlander
 
   module Publisher
@@ -53,7 +53,7 @@ module Cfhighlander
         template_url = getTemplateUrl
         region = s3_bucket_region(@component.highlander_dsl.distribution_bucket)
         return "https://console.aws.amazon.com/cloudformation/home?region=#{region}#/stacks/create/review?filter=active&templateURL=" +
-            "#{URI::encode(template_url)}&stackName=#{@component.name}"
+            "#{CGI::escape(template_url)}&stackName=#{@component.name}"
       end
 
       def publishFiles(file_list)


### PR DESCRIPTION
* URI::encode: https://github.com/ruby/ruby/blob/d92f09a5eea009fa28cd046e9d0eb698e3d94c5c/doc/NEWS-1.9.2#label-Library+updates+-28outstanding+ones+only-29 
![Captura de Tela 2021-07-06 às 15 35 24](https://user-images.githubusercontent.com/28915474/124650375-0f571200-de70-11eb-95bd-ed706263f575.png)

* Keyword arguments are now fully separated from positional arguments: https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments ![Keyword arguments are now fully separated from positional arguments](https://user-images.githubusercontent.com/28915474/124649944-88099e80-de6f-11eb-80c4-bfe2aa1d74dc.png)

Both of the changes made were tested on 2.7.3 and has backwards compatibility.