### PR TITLE
custom errors

### DIFF
--- a/lib/cfhighlander.error.rb
+++ b/lib/cfhighlander.error.rb
@@ -1,0 +1,3 @@
+module Cfhighlander
+    class Error < StandardError; end
+end

--- a/lib/util/cloudformation.util.rb
+++ b/lib/util/cloudformation.util.rb
@@ -1,4 +1,5 @@
 require_relative '../cfhighlander.model.component'
+require_relative '../cfhighlander.error'
 require_relative './debug.util'
 require 'duplicate'
 
@@ -295,6 +296,11 @@ module Cfhighlander
               outval_refs.each do |out_ref|
                 component_name = out_ref[:component]
                 ref_sub_component = template.subcomponents.find {|sc| sc.name == component_name}
+
+                if ref_sub_component.nil?
+                  raise Cfhighlander::Error, "unable to find outputs from component #{component_name} reference by parameters in component #{sub_component.name}"
+                end
+
                 if ref_sub_component.inlined
                   # out refs here need to be replaced with actual values
                   replacement = output_values[out_ref[:component]][out_ref[:outputName]]


### PR DESCRIPTION
### Catch and notify users of specific cfhighlander errors

https://github.com/theonestack/cfhighlander/commit/e5eb4647708c58a0d4ff0803e5529491ed3bb485 catch reference to unknown component in a cfout

```ruby
CfhighlanderTemplate do
  Component name: 'vpcv2', template: 'vpc-v2'
  Component name: 'fargate-v2', template: 'fargate-v2' do
    parameter name: 'SubnetIds', value: cfout('vpc.ComputeSubnets')
  end
end
```

```
unable to find outputs from component vpc reference by parameters in component fargate-v2 (Cfhighlander::Error)
```