### PR TITLE
Qualify inline sub-component output names to prevent config collisions

### DIFF
--- a/lib/cfhighlander.compiler.rb
+++ b/lib/cfhighlander.compiler.rb
@@ -35,12 +35,12 @@ module Cfhighlander
           :process_lambdas,
           :lambda_mock_resolve
 
-      def initialize(component)
+      def initialize(component, qualified_name = nil)
 
         @workdir = ENV['CFHIGHLANDER_WORKDIR']
         @component = component
         @sub_components = []
-        @component_name = component.highlander_dsl.name.downcase
+        @component_name = qualified_name || component.highlander_dsl.name.downcase
         @cfndsl_compiled = false
         @config_compiled = false
         @cfn_template_paths = []
@@ -58,8 +58,17 @@ module Cfhighlander
         end
 
         @component.highlander_dsl.subcomponents.each do |sub_component|
-          sub_component_compiler = Cfhighlander::Compiler::ComponentCompiler.new(sub_component.component_loaded)
-          sub_component_compiler.component_name = sub_component.name
+          # Inline sub-components share the parent's output directory and their
+          # resources get flattened into the parent template, so they don't need
+          # stable filenames. Qualify with parent name to prevent collisions when
+          # multiple sibling components define sub-components with the same name.
+          child_name = if sub_component.inlined
+            "#{@component_name}_#{sub_component.name}"
+          else
+            sub_component.name
+          end
+          sub_component_compiler = Cfhighlander::Compiler::ComponentCompiler.new(sub_component.component_loaded, child_name)
+          sub_component_compiler.component_name = child_name
           @sub_components << sub_component_compiler
         end
       end

--- a/spec/data/inline_config_isolation/src/child/child.cfhighlander.rb
+++ b/spec/data/inline_config_isolation/src/child/child.cfhighlander.rb
@@ -1,0 +1,7 @@
+CfhighlanderTemplate do
+
+  Name 'child'
+
+  Component template: 'grandchild', name: 'gc', render: Inline, config: @config
+
+end

--- a/spec/data/inline_config_isolation/src/child/child.cfndsl.rb
+++ b/spec/data/inline_config_isolation/src/child/child.cfndsl.rb
@@ -1,0 +1,3 @@
+CloudFormation do
+
+end

--- a/spec/data/inline_config_isolation/src/grandchild/grandchild.cfhighlander.rb
+++ b/spec/data/inline_config_isolation/src/grandchild/grandchild.cfhighlander.rb
@@ -1,0 +1,5 @@
+CfhighlanderTemplate do
+
+  Name 'grandchild'
+
+end

--- a/spec/data/inline_config_isolation/src/grandchild/grandchild.cfndsl.rb
+++ b/spec/data/inline_config_isolation/src/grandchild/grandchild.cfndsl.rb
@@ -1,0 +1,7 @@
+CloudFormation do
+
+  S3_Bucket(:ConfigBucket) do
+    BucketName bucket_prefix
+  end
+
+end

--- a/spec/data/inline_config_isolation/src/p.cfhighlander.rb
+++ b/spec/data/inline_config_isolation/src/p.cfhighlander.rb
@@ -1,0 +1,8 @@
+CfhighlanderTemplate do
+
+  Name 'p'
+
+  Component template: 'child', name: 'child_a', render: Inline, config: child_a
+  Component template: 'child', name: 'child_b', render: Inline, config: child_b
+
+end

--- a/spec/data/inline_config_isolation/src/p.cfndsl.rb
+++ b/spec/data/inline_config_isolation/src/p.cfndsl.rb
@@ -1,0 +1,3 @@
+CloudFormation do
+
+end

--- a/spec/data/inline_config_isolation/src/p.config.yaml
+++ b/spec/data/inline_config_isolation/src/p.config.yaml
@@ -1,0 +1,5 @@
+child_a:
+  bucket_prefix: alpha
+
+child_b:
+  bucket_prefix: beta

--- a/spec/test_inline_config_isolation_spec.rb
+++ b/spec/test_inline_config_isolation_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../bin/cfhighlander'
+require_relative '../lib/util/cloudformation.util'
+require 'rspec'
+require 'yaml'
+require 'fileutils'
+
+RSpec.describe Cfhighlander::Compiler::ComponentCompiler, "inline config isolation" do
+
+  context "when two inline instances of the same template have different configs" do
+    it "each instance compiles with its own config" do
+
+      src_dir = "#{File.dirname(__FILE__)}/data/inline_config_isolation/src"
+      ENV['CFHIGHLANDER_WORKDIR'] = src_dir
+
+      factory = Cfhighlander::Factory::ComponentFactory.new
+      component = factory.loadComponentFromTemplate('p')
+      component.load
+      component.eval_cfndsl
+
+      compiler = Cfhighlander::Compiler::ComponentCompiler.new(component)
+      model_flat = compiler.compileCloudFormation
+
+      resources = model_flat['Resources']
+
+      child_a_bucket = resources['ConfigBucket']
+      child_b_bucket = resources['childbConfigBucket']
+
+      expect(child_a_bucket).not_to be_nil, "expected child_a's ConfigBucket resource"
+      expect(child_b_bucket).not_to be_nil, "expected child_b's childbConfigBucket resource"
+
+      child_a_name = child_a_bucket['Properties']['BucketName']
+      child_b_name = child_b_bucket['Properties']['BucketName']
+
+      expect(child_a_name).to eq('alpha'), "child_a should use its own config"
+      expect(child_b_name).to eq('beta'), "child_b should use its own config"
+    end
+  end
+
+end


### PR DESCRIPTION
## Problem

When multiple sibling components use the same template with `render: Inline` (e.g. several `fargate-v2` instances each creating an `application-autoscaling` sub-component named `"autoscaling"`), the compiler writes their config and cfndsl output to the same filename. The last component to compile overwrites all previous ones, so every instance evaluates using a single shared config — the last writer wins.

**Example:** A project defines five ECS services as `fargate-v2` components. Each creates an inline `application-autoscaling` component which in turn creates an inline `ecs-scaling` sub-component named `"autoscaling"`. All five write to `autoscaling.config.yaml` and `autoscaling.compiled.cfndsl.rb`. The last one to compile overwrites the rest, causing all services to share identical scaling policies regardless of their individual config.

## Fix

Qualify inline sub-component `@component_name` values with their parent's component name, producing unique output filenames per instance. The qualified name is passed into the constructor via a new optional `qualified_name` parameter so it propagates recursively through the entire component tree.

Non-inline (nested stack) components keep their original unqualified names so that template URLs and S3 publishing paths remain compatible.

## Impact

- **Final flattened templates are unchanged** — inline resources are merged into the parent by `flattenCloudformation`, which is unaffected. The existing flatten spec passes.
- **Intermediate output filenames change** for all inline sub-components (e.g. `myTask.compiled.yaml` → `myproject_myservice_myTask.compiled.yaml`). Any tooling that references these intermediate paths will need updating.
- **Non-inline component filenames are unchanged** — no impact on template URLs or publishing.

## Testing

- Existing `test_cloudformation_util_spec` (flatten test) passes — confirms the final CloudFormation output is identical.
- New `test_inline_config_isolation_spec` — creates two inline instances of the same template with different configs (via a three-level parent/child/grandchild hierarchy to trigger the collision). Verified that the spec **fails against unpatched 0.13.4** (`child_a` gets `"beta"` instead of `"alpha"`) and **passes with the fix**.